### PR TITLE
feat: add env var OBSIDIAN_GIT for scripting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -277,7 +277,7 @@ export default class ObsidianGit extends Plugin {
 
     async push(): Promise<void> {
         this.setState(PluginState.push);
-        await this.git.push(
+        await this.git.env({ ...process.env, "OBSIDIAN_GIT": 1 }).push(
             (err: Error | null) => {
                 err && this.displayError(`Push failed ${err.message}`);
             }


### PR DESCRIPTION
I have a pre-push hook that ask for user confirmation. Sadly it makes obsidian-git push failed by timeout since I cannot make tty input.

A simple solution is to add an environment variable when spawn git process, check it in the hook and bypass the confirmation.

I also think configurable push command will be cool, but it's too much for this case.