### PR TITLE
FIX: Changed the branchLocal command to branch with no-color

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -591,7 +591,7 @@ class ObsidianGitSettingsTab extends PluginSettingTab {
             .setName("Current branch")
             .setDesc("Switch to a different branch")
             .addDropdown(async (dropdown) => {
-                const branchInfo = await plugin.git.branchLocal();
+                const branchInfo = await plugin.git.branch(['--no-color']);
                 for (const branch of branchInfo.all) {
                     dropdown.addOption(branch, branch);
                 }


### PR DESCRIPTION
Some git configurations will return ascii color codes when using the `simpleGit` command `branchLocal()`. This pr changes the `branchLocal()` call to `branch(['--no-color']). 

When `simpleGit.branch([options])` is called with at least one argument, it will only list local branches: https://github.com/steveukx/git-js/blob/0685a8b5d8558252bb50451d9c6c8b2bd474d0c8/src/lib/tasks/branch.ts#L18


### branchLocal() results 

```js
BranchSummaryResult {
  all: [ '\x1B[32mmaster\x1B[m' ],
  branches: {
    '\x1B[32mmaster\x1B[m': {
      current: true,
      name: '\x1B[32mmaster\x1B[m',
      commit: 'e686844',
      label: 'init commit'
    }
  },
  current: '\x1B[32mmaster\x1B[m',
  detached: false
}
```

### branch(['--no-color']) results 

```js
BranchSummaryResult {
  all: [ 'master' ],
  branches: {
    master: {
      current: true,
      name: 'master',
      commit: 'e686844',
      label: 'init commit'
    }
  },
  current: 'master',
  detached: false
}
```