### PR TITLE
Add new 'Sync Method' setting in place of `mergeOnPull` and new experimental obsidian-sync compatible sync method.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,10 +12,10 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     listChangedFilesInMessageBody: false,
     showStatusBar: true,
     updateSubmodules: false,
+    syncMethod: 'merge',
     gitPath: "",
     customMessageOnAutoBackup: false,
     autoBackupAfterFileChange: false,
-    mergeOnPull: true,
     treeStructure: false,
 };
 
@@ -29,4 +29,4 @@ export const DIFF_VIEW_CONFIG = {
     type: 'diff-view',
     name: 'Diff View',
     icon: 'feather-git-pull-request'
-}
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ export default class ObsidianGit extends Plugin {
     async onload() {
         console.log('loading ' + this.manifest.name + " plugin");
         await this.loadSettings();
+        this.migrateSettings();
 
         addIcons();
 
@@ -159,7 +160,6 @@ export default class ObsidianGit extends Plugin {
             }
         });
 
-        this.migrateSettings()
 
         if (this.settings.showStatusBar) {
             // init statusBar
@@ -174,10 +174,10 @@ export default class ObsidianGit extends Plugin {
     }
 
     migrateSettings() {
-        if(this.settings.mergeOnPull) {
-            this.settings.syncMethod = 'merge'
-            this.settings.mergeOnPull = undefined
-            this.saveSettings()
+        if (this.settings.mergeOnPull != undefined) {
+            this.settings.syncMethod = this.settings.mergeOnPull ? 'merge' : 'rebase';
+            this.settings.mergeOnPull = undefined;
+            this.saveSettings();
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,9 @@ export default class ObsidianGit extends Plugin {
                 new ChangedFilesModal(this, status.changed).open();
             }
         });
+
+        this.migrateSettings()
+
         if (this.settings.showStatusBar) {
             // init statusBar
             let statusBarEl = this.addStatusBarItem();
@@ -168,6 +171,14 @@ export default class ObsidianGit extends Plugin {
         }
         this.app.workspace.onLayoutReady(() => this.init());
 
+    }
+
+    migrateSettings() {
+        if(this.settings.mergeOnPull) {
+            this.settings.syncMethod = 'merge'
+            this.settings.mergeOnPull = undefined
+            this.saveSettings()
+        }
     }
 
     async onunload() {
@@ -386,11 +397,7 @@ export default class ObsidianGit extends Plugin {
         const pulledFilesLength = await this.gitManager.pull();
 
         if (pulledFilesLength > 0) {
-            if (this.settings.mergeOnPull) {
-                this.displayMessage(`Pulled ${pulledFilesLength} ${pulledFilesLength > 1 ? 'files' : 'file'} from remote`);
-            } else {
-                this.displayMessage("Rebased on pull");
-            }
+            this.displayMessage(`Pulled ${pulledFilesLength} ${pulledFilesLength > 1 ? 'files' : 'file'} from remote`);
         }
         return pulledFilesLength != 0;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,7 +91,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 const options: Record<SyncMethod, string> = {
                     'merge': 'Merge',
                     'rebase': 'Rebase',
-                    'reset': 'None (for use with Obsidian Sync)',
+                    'reset': 'Other sync service (Only updates the HEAD without touching the working directory)',
                 };
                 dropdown.addOptions(options);
                 dropdown.setValue(plugin.settings.syncMethod);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { Notice, PluginSettingTab, Setting } from "obsidian";
 import ObsidianGit from "./main";
+import { SyncMethod } from "./types";
 
 export class ObsidianGitSettingsTab extends PluginSettingTab {
     display(): void {
@@ -81,6 +82,28 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                         }
                     })
             );
+        new Setting(containerEl)
+            .setName("Sync Method")
+            .setDesc(
+                "Selects the method used for handling new changes found in your remote git repository."
+            )
+            .addDropdown(async (dropdown) => {
+                const options: Record<SyncMethod, string> = {
+                    'merge': 'Merge',
+                    'rebase': 'Rebase',
+                    'reset': 'None (for use with Obsidian Sync)',
+                }
+                dropdown.addOptions(options)
+                if (plugin.settings.syncMethod) {
+                    dropdown.setValue(plugin.settings.syncMethod)
+                } else {
+                    dropdown.setValue('merge')
+                }
+                dropdown.onChange(async (option) => {
+                    plugin.settings.syncMethod = option as SyncMethod
+                    plugin.saveSettings()
+                })
+            });
 
         new Setting(containerEl)
             .setName("Commit message")
@@ -184,17 +207,6 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     })
             );
 
-        new Setting(containerEl)
-            .setName("Merge on pull")
-            .setDesc("If turned on, merge on pull. If turned off, rebase on pull.")
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(plugin.settings.mergeOnPull)
-                    .onChange((value) => {
-                        plugin.settings.mergeOnPull = value;
-                        plugin.saveSettings();
-                    })
-            );
         new Setting(containerEl)
             .setName("Disable push")
             .setDesc("Do not push changes to the remote repository")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,22 +87,19 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             .setDesc(
                 "Selects the method used for handling new changes found in your remote git repository."
             )
-            .addDropdown(async (dropdown) => {
+            .addDropdown((dropdown) => {
                 const options: Record<SyncMethod, string> = {
                     'merge': 'Merge',
                     'rebase': 'Rebase',
                     'reset': 'None (for use with Obsidian Sync)',
-                }
-                dropdown.addOptions(options)
-                if (plugin.settings.syncMethod) {
-                    dropdown.setValue(plugin.settings.syncMethod)
-                } else {
-                    dropdown.setValue('merge')
-                }
-                dropdown.onChange(async (option) => {
-                    plugin.settings.syncMethod = option as SyncMethod
-                    plugin.saveSettings()
-                })
+                };
+                dropdown.addOptions(options);
+                dropdown.setValue(plugin.settings.syncMethod);
+
+                dropdown.onChange(async (option: SyncMethod) => {
+                    plugin.settings.syncMethod = option;
+                    plugin.saveSettings();
+                });
             });
 
         new Setting(containerEl)

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -176,6 +176,7 @@ export class SimpleGit extends GitManager {
             } else if (this.plugin.settings.syncMethod === 'reset') {
                 try {
                     await this.git.raw(['update-ref', `refs/heads/${branchInfo.current}`, upstreamCommit]);
+                    await this.unstageAll();
                 } catch (err) {
                     this.plugin.displayError(`Sync failed (${this.plugin.settings.syncMethod}): ${err.message}`);
                 }
@@ -186,12 +187,6 @@ export class SimpleGit extends GitManager {
         } else {
             return 0;
         }
-    }
-
-    private async getNewestRemoteCommit(): Promise<string> {
-        const branchInfo = await this.branchInfo();
-        const newestRemoteCommit = (await this.git.log([`-n 1 ${branchInfo.tracking}`])).all[0].hash;
-        return newestRemoteCommit;
     }
 
     async push(): Promise<number> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface ObsidianGitSettings {
     autoSaveInterval: number;
     autoPullInterval: number;
     autoPullOnBoot: boolean;
+    syncMethod: SyncMethod;
     disablePush: boolean;
     pullBeforePush: boolean;
     disablePopups: boolean;
@@ -13,9 +14,13 @@ export interface ObsidianGitSettings {
     gitPath: string;
     customMessageOnAutoBackup: boolean;
     autoBackupAfterFileChange: boolean;
-    mergeOnPull: boolean;
     treeStructure: boolean;
+
+    /* Obsolete settings */
+    mergeOnPull?: boolean;  // Migrated to `syncMethod = 'merge'`
 }
+
+export type SyncMethod = 'rebase' | 'merge' | 'reset'
 
 export interface Author {
     name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,13 @@ export interface ObsidianGitSettings {
     autoBackupAfterFileChange: boolean;
     treeStructure: boolean;
 
-    /* Obsolete settings */
-    mergeOnPull?: boolean;  // Migrated to `syncMethod = 'merge'`
+    /**
+     * @deprecated Migrated to `syncMethod = 'merge'`
+     */
+    mergeOnPull?: boolean;
 }
 
-export type SyncMethod = 'rebase' | 'merge' | 'reset'
+export type SyncMethod = 'rebase' | 'merge' | 'reset';
 
 export interface Author {
     name: string;


### PR DESCRIPTION
I use both obsidian-sync and obsidian-git so I can have both live updates & mobile support (via obsidian-sync) while also having change-by-change history (via obsidian-git).  While far from home over the holidays with my work laptop, I encountered more than a few merge conflicts due to a race condition in which my laptop at home dutifully received changes via obsidian-sync, committed them, and then while it attempted to push those changes, it discovered that my work laptop had already committed changes and was thus in a conflict.

What this does is add a third method for handling sync (in addition to the existing `rebase` and `merge` methods) that just lazily updates the current `HEAD` to match the sha of any fetched remote data *without updating the local filesystem*.  That might seem surprising at first glance, but while using obsidian-sync, this works perfectly well due to obsidian-sync itself updating your local filesystem automatically as changes are discovered -- almost universally long before obsidian-git has even had a chance to discover that those changes exist on the remote.  Additionally, if we keep obsidian-git _out_ of that process, it can perform its normal commit/push processes for keeping an accurate historical record of changes to your notes without the possibility of getting trapped in a conflict.

This also refactors _how_ we indicate to obsidian-git which sync method to use.  Before this change, there was a setting named `mergeOnPull` that is either `true` (indicating that we should merge fetched changes) or `false` (indicating that we should rebase atop fetched changes).  After this change, there is now a setting named `syncMethod` that can be set to one of three values: `merge`, `rebase`, or `reset` (this is the new obsidian-sync compatible option).  Settings will be automatically migrated forward at plugin load-time.

I've been using this successfully for a week or so now, but it's important for me to say that although I've tested this pretty thoroughly with the new `reset` method and spot-checked `merge` and `rebase`, it would be best if somebody who uses the more-normal sync methods gave this a shot, too, before merging.
