### PR TITLE
feat: add new background auto backup mode

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     commitMessage: "vault backup: {{date}}",
     commitDateFormat: "YYYY-MM-DD HH:mm:ss",
     autoSaveInterval: 0,
+    autoSaveIntervalMode: 'default',
     autoPullInterval: 0,
     autoPullOnBoot: false,
     disablePush: false,
@@ -15,7 +16,6 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     syncMethod: 'merge',
     gitPath: "",
     customMessageOnAutoBackup: false,
-    autoBackupAfterFileChange: false,
     treeStructure: false,
 };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -112,14 +112,17 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             );
         new Setting(containerEl)
             .setName("Sync Method")
-            .setDesc(
-                "Selects the method used for handling new changes found in your remote git repository."
-            )
+            .setDesc(createFragment((fragment) => {
+                fragment.appendText("Selects the method used for handling new changes found in your remote git repository.");
+                fragment.createEl('br');
+                fragment.createEl('br');
+                fragment.appendText("Note: Other sync service only updates the HEAD without touching the working directory");
+            }))
             .addDropdown((dropdown) => {
                 const options: Record<SyncMethod, string> = {
                     'merge': 'Merge',
                     'rebase': 'Rebase',
-                    'reset': 'Other sync service (Only updates the HEAD without touching the working directory)',
+                    'reset': 'Other sync service',
                 };
                 dropdown.addOptions(options);
                 dropdown.setValue(plugin.settings.syncMethod);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface ObsidianGitSettings {
     commitMessage: string;
     commitDateFormat: string;
     autoSaveInterval: number;
+    autoSaveIntervalMode: BackupIntervalMode;
     autoPullInterval: number;
     autoPullOnBoot: boolean;
     syncMethod: SyncMethod;
@@ -13,9 +14,12 @@ export interface ObsidianGitSettings {
     updateSubmodules: boolean;
     gitPath: string;
     customMessageOnAutoBackup: boolean;
-    autoBackupAfterFileChange: boolean;
     treeStructure: boolean;
 
+    /**
+     * @deprecated Migrated to `autoSaveIntervalMode = 'default'`
+     */
+    autoBackupAfterFileChange?: boolean;
     /**
      * @deprecated Migrated to `syncMethod = 'merge'`
      */
@@ -23,6 +27,8 @@ export interface ObsidianGitSettings {
 }
 
 export type SyncMethod = 'rebase' | 'merge' | 'reset';
+
+export type BackupIntervalMode = 'default' | 'after-change' | 'after-inactive';
 
 export interface Author {
     name: string;


### PR DESCRIPTION
This change introduces new auto backup mode discussed in https://github.com/denolehov/obsidian-git/issues/69#issuecomment-1028173943 that is triggered after X minutes of Obsidian window in background. If Obsidian window is focused while the timer is running, it is reset and new timer starts running only after Obisidian window is put to background again.

The new dropdown setting `autoSaveIntervalMode` also replaces existing toggle setting `autoBackupAfterFileChange` which is now deprecated.

Values of old toggle setting are migrated like this:
- `autoBackupAfterFileChange = false` -> `autoSaveIntervalMode = 'default'`
- `autoBackupAfterFileChange = true` -> `autoSaveIntervalMode = 'after-change'`

New mode has value `'after-inactive'`.