### PR TITLE
feat: custom git repository root

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     autoBackupAfterFileChange: false,
     treeStructure: false,
     refreshSourceControl: true,
+    basePath: "",
 };
 
 export const GIT_VIEW_CONFIG = {

--- a/src/gitManager.ts
+++ b/src/gitManager.ts
@@ -61,6 +61,8 @@ export abstract class GitManager {
 
     abstract updateGitPath(gitPath: string): void;
 
+    abstract updateBasePath(basePath: string): void;
+
     abstract getDiffString(filePath: string): Promise<string>;
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -306,7 +306,8 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             });
 
         new Setting(containerEl)
-            .setName("Base Path")
+            .setName("Git Repository Path")
+            .setDesc("Sets the relative path to the git repository.")
             .addText((cb) => {
                 cb.setValue(plugin.settings.basePath);
                 cb.onChange((value) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -304,6 +304,17 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     plugin.gitManager.updateGitPath(value || "git");
                 });
             });
+
+        new Setting(containerEl)
+            .setName("Base Path")
+            .addText((cb) => {
+                cb.setValue(plugin.settings.basePath);
+                cb.onChange((value) => {
+                    plugin.settings.basePath = value;
+                    plugin.saveSettings();
+                    plugin.gitManager.updateBasePath(value || "");
+                });
+            });
         const info = containerEl.createDiv();
         info.setAttr("align", "center");
         info.setText("Debugging and logging:\nYou can always see the logs of this and every other plugin by opening the console with");

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -20,9 +20,14 @@ export class SimpleGit extends GitManager {
         if (this.isGitInstalled()) {
             const adapter = this.app.vault.adapter as FileSystemAdapter;
             const path = adapter.getBasePath();
-            const extraPath = this.plugin.settings.basePath || ""
+            let extraPath = ""
+            // Because the basePath setting is a relative path, a leading `/` must
+            // be appended before concatenating with the path.
+            if (this.plugin.settings.basePath){
+              extraPath = "/" + this.plugin.settings.basePath;
+            }
             this.git = simpleGit({
-                baseDir: path + "/" + extraPath,
+                baseDir: path + extraPath,
                 binary: this.plugin.settings.gitPath || undefined,
                 config: ["core.quotepath=off"]
             });

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -19,8 +19,10 @@ export class SimpleGit extends GitManager {
         if (this.isGitInstalled()) {
             const adapter = this.app.vault.adapter as FileSystemAdapter;
             const path = adapter.getBasePath();
+            const extraPath = this.plugin.settings.basePath || ""
+            console.log(path + extraPath)
             this.git = simpleGit({
-                baseDir: path,
+                baseDir: path + extraPath,
                 binary: this.plugin.settings.gitPath || undefined,
                 config: ["core.quotepath=off"]
             });
@@ -301,6 +303,10 @@ export class SimpleGit extends GitManager {
     }
 
     updateGitPath(gitPath: string) {
+        this.setGitInstance();
+    }
+
+    updateBasePath(basePath: string) {
         this.setGitInstance();
     }
 

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "child_process";
 import { FileSystemAdapter } from "obsidian";
 import * as path from "path";
+import { sep } from "path";
 import * as simple from "simple-git";
 import simpleGit, { DefaultLogFields } from "simple-git";
 import { GitManager } from "./gitManager";
@@ -20,11 +21,11 @@ export class SimpleGit extends GitManager {
         if (this.isGitInstalled()) {
             const adapter = this.app.vault.adapter as FileSystemAdapter;
             const path = adapter.getBasePath();
-            let extraPath = ""
+            let extraPath = "";
             // Because the basePath setting is a relative path, a leading `/` must
             // be appended before concatenating with the path.
-            if (this.plugin.settings.basePath){
-              extraPath = "/" + this.plugin.settings.basePath;
+            if (this.plugin.settings.basePath) {
+                extraPath = sep + this.plugin.settings.basePath;
             }
             this.git = simpleGit({
                 baseDir: path + extraPath,

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -21,9 +21,8 @@ export class SimpleGit extends GitManager {
             const adapter = this.app.vault.adapter as FileSystemAdapter;
             const path = adapter.getBasePath();
             const extraPath = this.plugin.settings.basePath || ""
-            console.log(path + extraPath)
             this.git = simpleGit({
-                baseDir: path + extraPath,
+                baseDir: path + "/" + extraPath,
                 binary: this.plugin.settings.gitPath || undefined,
                 config: ["core.quotepath=off"]
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface ObsidianGitSettings {
      */
     mergeOnPull?: boolean;
     refreshSourceControl: boolean;
+    basePath: string;
 }
 
 export type SyncMethod = 'rebase' | 'merge' | 'reset';


### PR DESCRIPTION
## Context

For my use case, I wanted to have a public blog live within my obsidian vault. This blog is hosted and built on github pages and is a normal git repository. To keep things separated, the git repository be in a subfolder not at the root of the vault. This is unsupported currently and referenced in a few issues:

* https://github.com/denolehov/obsidian-git/issues/11 
* https://github.com/denolehov/obsidian-git/issues/169

## Solution

A setting was added called bath path that allows users to set a custom git root. This is then used by `simple-git` when configuring the SimpleGit RepoManger. 

<img width="602" alt="Screen Shot 2022-03-20 at 11 14 04 AM" src="https://user-images.githubusercontent.com/547496/159169296-cc00e201-cc5b-478a-a134-74893a3d0c73.png">

## Limitations

A user is only allowed on repo in the entire vault. I evaluated having multiple git repo support but it turned out to be a larger refactor than I had time for. For my use case this is totally fine. 


Thanks for the great plugin!

