### PR TITLE
Implement `Recently Pulled Files` section

### DIFF
--- a/src/gitManager.ts
+++ b/src/gitManager.ts
@@ -28,7 +28,7 @@ export abstract class GitManager {
 
     abstract discard(filepath: string): Promise<void>;
 
-    abstract pull(): Promise<number>;
+    abstract pull(): Promise<FileStatusResult[]>;
 
     abstract push(): Promise<number>;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ export default class ObsidianGit extends Plugin {
     timeoutIDPush: number;
     timeoutIDPull: number;
     lastUpdate: number;
+    lastPulledFiles: FileStatusResult[];
     gitReady = false;
     promiseQueue: PromiseQueue = new PromiseQueue();
     conflictOutputFile = "conflict-files-obsidian-git.md";
@@ -548,13 +549,14 @@ export default class ObsidianGit extends Plugin {
     /// Used for internals
     /// Returns whether the pull added a commit or not.
     async pull(): Promise<boolean> {
-        const pulledFilesLength = await this.gitManager.pull();
+        const pulledFiles = await this.gitManager.pull();
         this.offlineMode = false;
 
-        if (pulledFilesLength > 0) {
-            this.displayMessage(`Pulled ${pulledFilesLength} ${pulledFilesLength > 1 ? 'files' : 'file'} from remote`);
+        if (pulledFiles.length > 0) {
+            this.displayMessage(`Pulled ${pulledFiles.length} ${pulledFiles.length > 1 ? 'files' : 'file'} from remote`);
+            this.lastPulledFiles = pulledFiles;
         }
-        return pulledFilesLength != 0;
+        return pulledFiles.length != 0;
     }
 
     async stageCurrentFile(): Promise<boolean> {

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -210,7 +210,7 @@ export class SimpleGit extends GitManager {
         this.plugin.setState(PluginState.idle);
     }
 
-    async pull(): Promise<number> {
+    async pull(): Promise<FileStatusResult[]> {
         this.plugin.setState(PluginState.pull);
         if (this.plugin.settings.updateSubmodules)
             await this.git.subModule(["update", "--remote", "--merge", "--recursive"], (err) => this.onError(err));
@@ -248,9 +248,16 @@ export class SimpleGit extends GitManager {
             const afterMergeCommit = await this.git.revparse([branchInfo.current], (err) => this.onError(err));
 
             const filesChanged = await this.git.diff([`${localCommit}..${afterMergeCommit}`, '--name-only']);
-            return filesChanged.split(/\r\n|\r|\n/).filter((value) => value.length > 0).length;
+
+            return filesChanged.split(/\r\n|\r|\n/).filter((value) => value.length > 0).map((e) => {
+                return <FileStatusResult>{
+                    path: e,
+                    working_dir: 'P',
+                    vault_path: this.getVaultPath(e),
+                };
+            });
         } else {
-            return 0;
+            return [];
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,9 @@ export interface DiffViewState {
     staged: boolean,
     file: string,
 }
+
+export enum FileType {
+    staged,
+    changed,
+    pulled,
+}

--- a/src/ui/sidebar/components/pulledFileComponent.svelte
+++ b/src/ui/sidebar/components/pulledFileComponent.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { setIcon, Workspace } from "obsidian";
+  import { hoverPreview, openOrSwitch } from "obsidian-community-lib";
+  import { FileStatusResult } from "src/types";
+  import GitView from "../sidebarView";
+
+  export let change: FileStatusResult;
+  export let view: GitView;
+  $: side = (view.leaf.getRoot() as any).side == "left" ? "right" : "left";
+
+  function hover(event: MouseEvent) {
+    //Don't show previews of config- or hidden files.
+    if (
+      !change.path.startsWith(view.app.vault.configDir) ||
+      !change.path.startsWith(".")
+    ) {
+      hoverPreview(
+        event,
+        view as any,
+        change.vault_path.split("/").last().replace(".md", "")
+      );
+    }
+  }
+
+  function open(event: MouseEvent) {
+    if (
+      !(
+        change.path.startsWith(view.app.vault.configDir) ||
+        change.path.startsWith(".") ||
+        change.working_dir === "D"
+      )
+    ) {
+      openOrSwitch(change.vault_path, event);
+    }
+  }
+</script>
+
+<main on:mouseover={hover} on:click|self={open} on:focus>
+  <span
+    class="path"
+    aria-label-position={side}
+    aria-label={change.vault_path.split("/").last() != change.vault_path
+      ? change.vault_path
+      : ""}
+    on:click|self={open}
+  >
+    {change.vault_path.split("/").last().replace(".md", "")}
+  </span>
+  <div class="tools">
+    <span class="type" data-type={change.working_dir}>{change.working_dir}</span
+    >
+  </div>
+</main>
+
+<style lang="scss">
+  main {
+    cursor: pointer;
+    background-color: var(--background-secondary);
+    border-radius: 4px;
+    width: 98%;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    margin-bottom: 2px;
+
+    .path {
+      color: var(--text-muted);
+      white-space: nowrap;
+      max-width: 75%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &:hover .path {
+      color: var(--text-normal);
+      transition: all 200ms;
+    }
+
+    .tools {
+      display: flex;
+      align-items: center;
+
+      .type {
+        height: 16px;
+        width: 16px;
+        margin: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        &[data-type="M"] {
+          color: orange;
+        }
+        &[data-type="D"] {
+          color: red;
+        }
+      }
+    }
+  }
+</style>

--- a/src/ui/sidebar/components/treeComponent.svelte
+++ b/src/ui/sidebar/components/treeComponent.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import ObsidianGit from "src/main";
-  import { TreeItem } from "src/types";
+  import { FileType, TreeItem } from "src/types";
   import { slide } from "svelte/transition";
   import GitView from "../sidebarView";
   import FileComponent from "./fileComponent.svelte";
+  import PulledFileComponent from "./pulledFileComponent.svelte";
   import StagedFileComponent from "./stagedFileComponent.svelte";
   export let hierarchy: TreeItem;
   export let plugin: ObsidianGit;
   export let view: GitView;
-  export let staged: boolean;
+  export let fileType: FileType;
   export let topLevel = false;
 
   const closed: Record<string, boolean> = {};
@@ -18,19 +19,21 @@
   {#each hierarchy.children as entity}
     {#if entity.statusResult}
       <div class="file-view">
-        {#if staged}
+        {#if fileType == FileType.staged}
           <StagedFileComponent
             change={entity.statusResult}
             manager={plugin.gitManager}
             {view}
           />
-        {:else}
+        {:else if fileType == FileType.changed}
           <FileComponent
             change={entity.statusResult}
             manager={plugin.gitManager}
             {view}
             workspace={plugin.app.workspace}
           />
+        {:else if fileType == FileType.pulled}
+          <PulledFileComponent change={entity.statusResult} {view} />
         {/if}
       </div>
     {:else}
@@ -60,7 +63,7 @@
       </div>
       {#if !closed[entity.title]}
         <div class="file-view" transition:slide|local={{ duration: 75 }}>
-          <svelte:self hierarchy={entity} {plugin} {view} {staged} />
+          <svelte:self hierarchy={entity} {plugin} {view} {fileType} />
         </div>
       {/if}
     {/if}

--- a/src/ui/sidebar/gitView.svelte
+++ b/src/ui/sidebar/gitView.svelte
@@ -296,52 +296,54 @@
           </div>
         {/if}
       </div>
-      <div class="pulled">
-        <div
-          class="opener tree-item-self is-clickable"
-          class:open={lastPulledFilesOpen}
-          on:click={() => (lastPulledFilesOpen = !lastPulledFilesOpen)}
-        >
-          <div>
-            <div class="tree-item-icon collapse-icon" style="">
-              <svg
-                viewBox="0 0 100 100"
-                class="right-triangle"
-                width="8"
-                height="8"
-                ><path
-                  fill="currentColor"
-                  stroke="currentColor"
-                  d="M94.9,20.8c-1.4-2.5-4.1-4.1-7.1-4.1H12.2c-3,0-5.7,1.6-7.1,4.1c-1.3,2.4-1.2,5.2,0.2,7.6L43.1,88c1.5,2.3,4,3.7,6.9,3.7 s5.4-1.4,6.9-3.7l37.8-59.6C96.1,26,96.2,23.2,94.9,20.8L94.9,20.8z"
-                /></svg
-              >
+      {#if lastPulledFiles.length > 0}
+        <div class="pulled">
+          <div
+            class="opener tree-item-self is-clickable"
+            class:open={lastPulledFilesOpen}
+            on:click={() => (lastPulledFilesOpen = !lastPulledFilesOpen)}
+          >
+            <div>
+              <div class="tree-item-icon collapse-icon" style="">
+                <svg
+                  viewBox="0 0 100 100"
+                  class="right-triangle"
+                  width="8"
+                  height="8"
+                  ><path
+                    fill="currentColor"
+                    stroke="currentColor"
+                    d="M94.9,20.8c-1.4-2.5-4.1-4.1-7.1-4.1H12.2c-3,0-5.7,1.6-7.1,4.1c-1.3,2.4-1.2,5.2,0.2,7.6L43.1,88c1.5,2.3,4,3.7,6.9,3.7 s5.4-1.4,6.9-3.7l37.8-59.6C96.1,26,96.2,23.2,94.9,20.8L94.9,20.8z"
+                  /></svg
+                >
+              </div>
+              <span>Recently Pulled Changes</span>
             </div>
-            <span>Recently Pulled Changes</span>
+            <span class="tree-item-flair">{lastPulledFiles.length}</span>
           </div>
-          <span class="tree-item-flair">{lastPulledFiles.length}</span>
-        </div>
-        {#if lastPulledFilesOpen}
-          <div class="file-view" transition:slide|local={{ duration: 150 }}>
-            {#if showTree}
-              <TreeComponent
-                hierarchy={lastPulledFilesHierarchy}
-                {plugin}
-                {view}
-                fileType={FileType.pulled}
-                topLevel={true}
-              />
-            {:else}
-              {#each lastPulledFiles as change}
-                <PulledFileComponent
-                  {change}
+          {#if lastPulledFilesOpen}
+            <div class="file-view" transition:slide|local={{ duration: 150 }}>
+              {#if showTree}
+                <TreeComponent
+                  hierarchy={lastPulledFilesHierarchy}
+                  {plugin}
                   {view}
-                  on:git-refresh={triggerRefresh}
+                  fileType={FileType.pulled}
+                  topLevel={true}
                 />
-              {/each}
-            {/if}
-          </div>
-        {/if}
-      </div>
+              {:else}
+                {#each lastPulledFiles as change}
+                  <PulledFileComponent
+                    {change}
+                    {view}
+                    on:git-refresh={triggerRefresh}
+                  />
+                {/each}
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
     {/if}
   </div>
 </main>

--- a/src/ui/sidebar/gitView.svelte
+++ b/src/ui/sidebar/gitView.svelte
@@ -70,6 +70,14 @@
 
   async function refresh() {
     status = plugin.cachedStatus;
+    if (plugin.lastPulledFiles && plugin.lastPulledFiles != lastPulledFiles) {
+      lastPulledFiles = plugin.lastPulledFiles;
+      
+      lastPulledFilesHierarchy = {
+        title: "",
+        children: plugin.gitManager.getTreeStructure(lastPulledFiles),
+      };
+    }
     if (status) {
       changeHierarchy = {
         title: "",
@@ -78,10 +86,6 @@
       stagedHierarchy = {
         title: "",
         children: plugin.gitManager.getTreeStructure(status.staged),
-      };
-      lastPulledFilesHierarchy = {
-        title: "",
-        children: plugin.gitManager.getTreeStructure(lastPulledFiles),
       };
     }
     loading = plugin.loading;
@@ -108,14 +112,7 @@
   }
   function pull() {
     loading = true;
-    plugin
-      .pullChangesFromRemote()
-      .then(() => {
-        if (plugin.lastPulledFiles != null) {
-          lastPulledFiles = plugin.lastPulledFiles;
-        }
-      })
-      .finally(triggerRefresh);
+    plugin.pullChangesFromRemote().finally(triggerRefresh);
   }
 </script>
 

--- a/src/ui/sidebar/gitView.svelte
+++ b/src/ui/sidebar/gitView.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { debounce, EventRef, MetadataCache, setIcon } from "obsidian";
   import ObsidianGit from "src/main";
-  import { PluginState, Status, TreeItem } from "src/types";
+  import {
+    PluginState,
+    Status,
+    TreeItem,
+    FileStatusResult,
+    FileType,
+  } from "src/types";
   import { onDestroy } from "svelte";
   import { slide } from "svelte/transition";
   import FileComponent from "./components/fileComponent.svelte";
+  import PulledFileComponent from "./components/pulledFileComponent.svelte";
   import StagedFileComponent from "./components/stagedFileComponent.svelte";
   import TreeComponent from "./components/treeComponent.svelte";
   import GitView from "./sidebarView";
@@ -13,12 +20,15 @@
   export let view: GitView;
   let loading: boolean;
   let status: Status | null;
+  let lastPulledFiles: FileStatusResult[] = [];
   let commitMessage = plugin.settings.commitMessage;
   let buttons: HTMLElement[] = [];
   let changeHierarchy: TreeItem;
   let stagedHierarchy: TreeItem;
+  let lastPulledFilesHierarchy: TreeItem;
   let changesOpen = true;
   let stagedOpen = true;
+  let lastPulledFilesOpen = true;
 
   let showTree = plugin.settings.treeStructure;
   let layoutBtn: HTMLElement;
@@ -43,7 +53,7 @@
 
   async function commit() {
     loading = true;
-    
+
     if (await plugin.hasTooBigFiles(status.staged)) {
       plugin.setState(PluginState.idle);
       return false;
@@ -68,6 +78,10 @@
       stagedHierarchy = {
         title: "",
         children: plugin.gitManager.getTreeStructure(status.staged),
+      };
+      lastPulledFilesHierarchy = {
+        title: "",
+        children: plugin.gitManager.getTreeStructure(lastPulledFiles),
       };
     }
     loading = plugin.loading;
@@ -94,7 +108,14 @@
   }
   function pull() {
     loading = true;
-    plugin.pullChangesFromRemote().finally(triggerRefresh);
+    plugin
+      .pullChangesFromRemote()
+      .then(() => {
+        if (plugin.lastPulledFiles != null) {
+          lastPulledFiles = plugin.lastPulledFiles;
+        }
+      })
+      .finally(triggerRefresh);
   }
 </script>
 
@@ -212,7 +233,7 @@
                 hierarchy={stagedHierarchy}
                 {plugin}
                 {view}
-                staged={true}
+                fileType={FileType.staged}
                 topLevel={true}
               />
             {:else}
@@ -258,7 +279,7 @@
                 hierarchy={changeHierarchy}
                 {plugin}
                 {view}
-                staged={false}
+                fileType={FileType.changed}
                 topLevel={true}
               />
             {:else}
@@ -268,6 +289,52 @@
                   {view}
                   manager={plugin.gitManager}
                   workspace={plugin.app.workspace}
+                  on:git-refresh={triggerRefresh}
+                />
+              {/each}
+            {/if}
+          </div>
+        {/if}
+      </div>
+      <div class="pulled">
+        <div
+          class="opener tree-item-self is-clickable"
+          class:open={lastPulledFilesOpen}
+          on:click={() => (lastPulledFilesOpen = !lastPulledFilesOpen)}
+        >
+          <div>
+            <div class="tree-item-icon collapse-icon" style="">
+              <svg
+                viewBox="0 0 100 100"
+                class="right-triangle"
+                width="8"
+                height="8"
+                ><path
+                  fill="currentColor"
+                  stroke="currentColor"
+                  d="M94.9,20.8c-1.4-2.5-4.1-4.1-7.1-4.1H12.2c-3,0-5.7,1.6-7.1,4.1c-1.3,2.4-1.2,5.2,0.2,7.6L43.1,88c1.5,2.3,4,3.7,6.9,3.7 s5.4-1.4,6.9-3.7l37.8-59.6C96.1,26,96.2,23.2,94.9,20.8L94.9,20.8z"
+                /></svg
+              >
+            </div>
+            <span>Recently Pulled Changes</span>
+          </div>
+          <span class="tree-item-flair">{lastPulledFiles.length}</span>
+        </div>
+        {#if lastPulledFilesOpen}
+          <div class="file-view" transition:slide|local={{ duration: 150 }}>
+            {#if showTree}
+              <TreeComponent
+                hierarchy={lastPulledFilesHierarchy}
+                {plugin}
+                {view}
+                fileType={FileType.pulled}
+                topLevel={true}
+              />
+            {:else}
+              {#each lastPulledFiles as change}
+                <PulledFileComponent
+                  {change}
+                  {view}
                   on:git-refresh={triggerRefresh}
                 />
               {/each}


### PR DESCRIPTION
This PR implements #260
Each time the user pulls at least one file, the list of pulled files will be shown in the new section. After app restart, this list will be empty as we are not storing any history.

TreeView:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/9114994/183265509-6ac8d8a7-5fb6-4267-946c-295de862e090.png">

DefaultView:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/9114994/183265517-1ccb2b6f-4508-4871-87ee-c08fd4d9b329.png">
 