### PR TITLE
fixed grammatical error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -478,7 +478,7 @@ export default class ObsidianGit extends Plugin {
                 }
             }
             const committedFiles = await this.gitManager.commitAll(commitMessage);
-            this.displayMessage(`Committed ${committedFiles} ${committedFiles > 1 ? 'files' : 'file'}`);
+            this.displayMessage(`Committed ${committedFiles} ${committedFiles == 1 ? 'files' : 'file'}`);
         } else {
             this.displayMessage("No changes to commit");
         }


### PR DESCRIPTION
when there is 0 of something you use a plural noun. sometimes you commit 0 files, like when you resolve conflicts it says "committed 0 file". it was a bit annoying so i fixed it.