### PR TITLE
Dockerized setup for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+# Installs the NPM dependencies for the execution inside docker container
+
+FROM node:18-slim
+
+WORKDIR /app
+
+COPY *.json esbuild.config.mjs polyfill_buffer.js ./

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,30 @@
+# compose definitions of reproducable builds
+# use scripts/restart{dev,prod}.sh to use these
+
+version: "3.9"
+
+services:
+  plugin-watchmode-for-dev:
+    build:
+      dockerfile: docker/Dockerfile
+      context: ..
+    container_name: plugin-runner
+    image: obsidian-git:v1
+    volumes:
+      - ${PWD}:/app
+    network_mode: host
+    command: ./docker/docker-command.sh dev
+    # command: /bin/bash
+    # stdin_open: true # docker run -i
+    # tty: true # docker run -t
+
+  plugin-build-for-prod:
+    build:
+      dockerfile: docker/Dockerfile
+      context: ..
+    container_name: plugin-creator
+    image: obsidian-git:v1
+    volumes:
+      - ${PWD}:/app
+    network_mode: host
+    command: ./docker/docker-command.sh prod

--- a/docker/docker-command.sh
+++ b/docker/docker-command.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# This script is run within the docker container
+
+npm install
+
+npm audit || true
+
+if [[ "$1" == "prod" ]]; then
+  npm run build
+else
+  npm run dev
+fi

--- a/scripts/0-prepare-start.sh
+++ b/scripts/0-prepare-start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+./scripts/1-stop.sh
+
+docker-compose -f docker/compose.yml build

--- a/scripts/1-stop.sh
+++ b/scripts/1-stop.sh
@@ -1,0 +1,1 @@
+docker-compose -f docker/compose.yml down || true

--- a/scripts/restart-dev.sh
+++ b/scripts/restart-dev.sh
@@ -1,0 +1,6 @@
+./scripts/0-prepare-start.sh dev &&
+  docker-compose -f docker/compose.yml run --rm plugin-watchmode-for-dev
+
+# Now open the test-vault in obsidian and work with it.
+# Reload the plugins with Ctrl + Shift + I (Developer Mode) and
+# then with Ctrl + Shift + R (reload Obsidian).

--- a/scripts/restart-prod.sh
+++ b/scripts/restart-prod.sh
@@ -1,0 +1,4 @@
+./scripts/0-prepare-start.sh prod &&
+  docker-compose -f docker/compose.yml run --rm plugin-build-for-prod
+
+# Then open the test-vault in obsidian


### PR DESCRIPTION
As discussed with @Vinzent03, this PR contains the setup that can be used by new developers to quickly get into this plugin - as all they need to have is Docker. Simply running `scripts/restart-dev.sh` will install all dependencies and run the compiler in watch-mode.

I've extracted this code from #288.

This PR is a draft, since it was decided to not merge this. Hence, this is here primarily for future reference.

If you want, we can move this into an issue instead.