### PR TITLE
git log on GitManager interface

### DIFF
--- a/src/gitManager.ts
+++ b/src/gitManager.ts
@@ -211,4 +211,8 @@ export abstract class GitManager {
         }
         return template;
     }
+
+    // https://github.com/denolehov/obsidian-git/issues/73#issuecomment-1272641543
+    abstract log(file: string, relativeToVault: boolean): Promise<readonly any[]>;
+
 }

--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -781,6 +781,10 @@ export class IsomorphicGit extends GitManager {
             return new Notice(message, this.noticeLength);
         }
     }
+
+    async log(file: string, relativeToVault: boolean): Promise<readonly any[]> {
+        // TODO implement
+    }
 }
 
 // All because we can't use (for await)...


### PR DESCRIPTION
Is this what you meant [here](https://github.com/denolehov/obsidian-git/issues/73#issuecomment-1273049869) @Vinzent03?
I left a todo where the mobile implementation should be. You might want to refactor the placement and the types.
Alternatively, for my specific use case a `lastCommitDate()` function on GitManager would be ideal, but I don't know if you'd want that on the interface.