### PR TITLE
Update Description for Auto Backup-Toggle

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,7 +70,8 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 );
 
             new Setting(containerEl)
-                .setName(`If turned on, do auto ${commitOrBackup} every X minutes after last change. Prevents auto ${commitOrBackup} while editing a file. If turned off, do auto ${commitOrBackup} every X minutes. It's independent from last change.`)
+                .setName(`Auto Backup after Filechange`)
+                .setDesc(`If turned on, do auto ${commitOrBackup} every ${plugin.settings.autoSaveInterval} minutes after last change. This also prevents auto ${commitOrBackup} while editing a file. If turned off, it's independent from last the change.`)
                 .addToggle((toggle) =>
                     toggle
                         .setValue(plugin.settings.autoBackupAfterFileChange)


### PR DESCRIPTION
For some reason, I wasn't able to run this locally so I had to do it on GitHub itself, I hope my changes in the settings make sense. 

I was confused by the setting for auto backups for file changes, because of that I added a name and changed the description so it should be clear. 

Does something happen when the toggle is `off` if not, then the "If turned off, ..." was redundant anyway?! 

If you need anything else, let me know. Great plugin by the way. 🙌🏼 