### PR TITLE
Fix bug in hiding mobile notifications

### DIFF
--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -303,7 +303,9 @@ export class IsomorphicGit extends GitManager {
                 ...this.getRepo(),
                 ref: branchInfo.current,
                 onProgress: (progress) => {
-                    (progressNotice as any).noticeEl.innerText = this.getProgressText("Checkout", progress);
+                    if (progressNotice !== undefined) {
+                        (progressNotice as any).noticeEl.innerText = this.getProgressText("Checkout", progress);
+                    }
                 },
                 remote: branchInfo.remote,
             }));
@@ -348,7 +350,9 @@ export class IsomorphicGit extends GitManager {
             await this.wrapFS(git.push({
                 ...this.getRepo(),
                 onProgress: (progress) => {
-                    (progressNotice as any).noticeEl.innerText = this.getProgressText("Pushing", progress);
+                    if (progressNotice !== undefined) {
+                        (progressNotice as any).noticeEl.innerText = this.getProgressText("Pushing", progress);
+                    }
                 }
             }));
             progressNotice?.hide();
@@ -463,7 +467,9 @@ export class IsomorphicGit extends GitManager {
                 dir: dir,
                 url: url,
                 onProgress: (progress) => {
-                    (progressNotice as any).noticeEl.innerText = this.getProgressText("Cloning", progress);
+                    if (progressNotice !== undefined) {
+                        (progressNotice as any).noticeEl.innerText = this.getProgressText("Cloning", progress);
+                    }
                 }
             }));
             progressNotice?.hide();
@@ -506,7 +512,9 @@ export class IsomorphicGit extends GitManager {
             const args: any = {
                 ...this.getRepo(),
                 onProgress: (progress: GitProgressEvent) => {
-                    (progressNotice as any).noticeEl.innerText = this.getProgressText("Fetching", progress);
+                    if (progressNotice !== undefined) {
+                        (progressNotice as any).noticeEl.innerText = this.getProgressText("Fetching", progress);
+                    }
                 },
                 remote: remote ?? await this.getCurrentRemote()
             };


### PR DESCRIPTION
Further fix for #292 

There was a fix made in commit `7d6252795ca62f4176fee90d674041659a0a1d9f`, however, this introduced a bug where "progressNotice" could be undefined, and the progress function was attempting to set a property on this undefined object. This would throw an error, and many git operations could not be performed.

I simply wrapped the progressNotice in an if statement to check if it was defined - without tests I am not sure if there are side effects, but this might work.