### PR TITLE
Adds option to recursively checkout submodules

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -452,7 +452,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
         containerEl.createEl("br");
         containerEl.createEl("h3", { text: "Advanced" });
 
-		if (plugin.gitManager instanceof SimpleGit) {
+        if (plugin.gitManager instanceof SimpleGit) {
             new Setting(containerEl)
                 .setName("Update submodules")
                 .setDesc('"Create backup" and "pull" takes care of submodules. Missing features: Conflicted files, count of pulled/pushed/committed files. Tracking branch needs to be set for each submodule')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -452,7 +452,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
         containerEl.createEl("br");
         containerEl.createEl("h3", { text: "Advanced" });
 
-        if (plugin.gitManager instanceof SimpleGit)
+		if (plugin.gitManager instanceof SimpleGit) {
             new Setting(containerEl)
                 .setName("Update submodules")
                 .setDesc('"Create backup" and "pull" takes care of submodules. Missing features: Conflicted files, count of pulled/pushed/committed files. Tracking branch needs to be set for each submodule')
@@ -464,6 +464,21 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                             plugin.saveSettings();
                         })
                 );
+            if (plugin.settings.updateSubmodules) {
+                new Setting(containerEl)
+                    .setName('Submodule recurse checkout/switch')
+                    .setDesc('Whenever a checkout happens on the root repository, recurse the checkout on the submodules (if the branches exist).')
+                    .addToggle((toggle) =>
+                        toggle
+                            .setValue(plugin.settings.submoduleRecurseCheckout)
+                            .onChange((value) => {
+                                plugin.settings.submoduleRecurseCheckout = value;
+                                plugin.saveSettings();
+                            })
+                    );
+            }
+        }
+
 
         if (plugin.gitManager instanceof SimpleGit)
             new Setting(containerEl)

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -97,7 +97,7 @@ export class SimpleGit extends GitManager {
                         const strippedSubmods: string[] = submods.map(i => {
                             const submod = i.match(/'([^']*)'/);
                             if (submod != undefined) {
-                                return root + '/' + submod[ 1 ] + sep;
+                                return root + '/' + submod[1] + sep;
                             }
                         }).filter((i): i is string => !!i);
 

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -82,7 +82,6 @@ export class SimpleGit extends GitManager {
                 this.git.outputHandler(async (cmd, stdout, stderr, args) => {
                     // Do not run this handler on other commands
                     if (!(args.contains('submodule') && args.contains('foreach'))) {
-                        resolve([]);
                         return;
                     }
 

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -76,6 +76,45 @@ export class SimpleGit extends GitManager {
         };
     }
 
+    async getSubmodulePaths(): Promise<string[]> {
+        return new Promise<string[]>(async (resolve) => {
+            if (this.plugin.settings.submoduleRecurseCheckout) {
+                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
+                    // Do not run this handler on other commands
+                    if (!(args.contains('submodule') && args.contains('foreach'))) {
+                        resolve([]);
+                        return;
+                    }
+
+                    let body = '';
+                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? '/' + this.plugin.settings.basePath : '');
+                    stdout.on('data', (chunk) => {
+                        body += chunk.toString('utf8');
+                    });
+                    stdout.on('end', async () => {
+                        const submods = body.split('\n');
+
+                        // Remove words like `Entering` in front of each line and filter empty lines
+                        const strippedSubmods: string[] = submods.map(i => {
+                            const submod = i.match(/'([^']*)'/);
+                            if (submod != undefined) {
+                                return root + '/' + submod[ 1 ] + sep;
+                            }
+                        }).filter((i): i is string => !!i);
+
+                        strippedSubmods.reverse();
+                        resolve(strippedSubmods);
+                    });
+                });
+
+                await this.git.subModule(['foreach', '--recursive', '']);
+                this.git.outputHandler(() => {
+                });
+            }
+        });
+    }
+
+
     //Remove wrong `"` like "My file.md"
     formatPath(path: { from?: string, path: string; }, renamed = false): { path: string, from?: string; } {
         function format(path?: string): string | undefined {
@@ -102,46 +141,11 @@ export class SimpleGit extends GitManager {
     async commitAll({ message }: { message: string; }): Promise<number> {
         if (this.plugin.settings.updateSubmodules) {
             this.plugin.setState(PluginState.commit);
-            await new Promise<void>(async (resolve, reject) => {
-
-                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
-
-                    // Do not run this handler on other commands
-                    if (!(args.contains("submodule") && args.contains("foreach"))) return;
-
-                    let body = "";
-                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? "/" + this.plugin.settings.basePath : "");
-                    stdout.on('data', (chunk) => {
-                        body += chunk.toString('utf8');
-                    });
-                    stdout.on('end', async () => {
-                        const submods = body.split('\n');
-
-                        // Remove words like `Entering` in front of each line and filter empty lines
-                        const strippedSubmods = submods.map(i => {
-                            const submod = i.match(/'([^']*)'/);
-                            if (submod != undefined) {
-                                return root + "/" + submod[1] + sep;
-                            }
-                        });
-
-                        strippedSubmods.reverse();
-                        for (const item of strippedSubmods) {
-                            // Catch empty lines
-                            if (item != undefined) {
-                                await this.git.cwd({ path: item, root: false }).add("-A", (err) => this.onError(err));
-                                await this.git.cwd({ path: item, root: false }).commit(await this.formatCommitMessage(message), (err) => this.onError(err));
-                            }
-                        }
-                        resolve();
-                    });
-                });
-
-
-                await this.git.subModule(["foreach", "--recursive", '']);
-                this.git.outputHandler(() => { });
-            });
-
+            const submodulePaths = await this.getSubmodulePaths();
+            for (const item of submodulePaths) {
+                await this.git.cwd({ path: item, root: false }).add("-A", (err) => this.onError(err));
+                await this.git.cwd({ path: item, root: false }).commit(await this.formatCommitMessage(message), (err) => this.onError(err));
+            }
         }
         this.plugin.setState(PluginState.add);
 
@@ -329,47 +333,15 @@ export class SimpleGit extends GitManager {
 
     async checkout(branch: string): Promise<void> {
         await this.git.checkout(branch, (err) => this.onError(err));
-        await new Promise<void>(async (resolve, reject) => {
-            if (this.plugin.settings.submoduleRecurseCheckout) {
-                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
-                    // Do not run this handler on other commands
-                    if (!(args.contains('submodule') && args.contains('foreach'))) return;
-
-                    let body = '';
-                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? '/' + this.plugin.settings.basePath : '');
-                    stdout.on('data', (chunk) => {
-                        body += chunk.toString('utf8');
-                    });
-                    stdout.on('end', async () => {
-                        const submods = body.split('\n');
-
-                        // Remove words like `Entering` in front of each line and filter empty lines
-                        const strippedSubmods = submods.map(i => {
-                            const submod = i.match(/'([^']*)'/);
-                            if (submod != undefined) {
-                                return root + '/' + submod[ 1 ] + sep;
-                            }
-                        });
-
-                        strippedSubmods.reverse();
-                        for (const item of strippedSubmods) {
-                            // Catch empty lines
-                            if (item != undefined) {
-                                let branchSummary = await this.git.cwd({ path: item, root: false }).branch();
-                                if (Object.keys(branchSummary.branches).includes(branch)) {
-                                    await this.git.cwd({ path: item, root: false }).checkout(branch, (err) => this.onError(err));
-                                }
-                            }
-                        }
-                        resolve();
-                    });
-                });
-
-                await this.git.subModule(['foreach', '--recursive', '']);
-                this.git.outputHandler(() => {
-                });
+        if (this.plugin.settings.submoduleRecurseCheckout) {
+            const submodulePaths = await this.getSubmodulePaths();
+            for (const submodulePath of submodulePaths) {
+                let branchSummary = await this.git.cwd({ path: submodulePath, root: false }).branch();
+                if (Object.keys(branchSummary.branches).includes(branch)) {
+                    await this.git.cwd({ path: submodulePath, root: false }).checkout(branch, (err) => this.onError(err));
+                }
             }
-        });
+        }
     }
 
     async createBranch(branch: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,6 @@ export interface ObsidianGitSettings {
     showStatusBar: boolean;
     updateSubmodules: boolean;
 	submoduleRecurseCheckout: boolean;
-	matchRootBranchName: boolean;
 	/**
     * @deprecated Using `localstorage` instead
     */

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface ObsidianGitSettings {
     listChangedFilesInMessageBody: boolean;
     showStatusBar: boolean;
     updateSubmodules: boolean;
+	submoduleRecurseCheckout: boolean;
     /**
     * @deprecated Using `localstorage` instead
     */

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,8 @@ export interface ObsidianGitSettings {
     showStatusBar: boolean;
     updateSubmodules: boolean;
 	submoduleRecurseCheckout: boolean;
-    /**
+	matchRootBranchName: boolean;
+	/**
     * @deprecated Using `localstorage` instead
     */
     gitPath?: string;


### PR DESCRIPTION
This commit allows users to automatically checkout the same branch in submodules (if present) as the root repository. This does not create any branches.

Additional refactor for retrieval of submodule paths to allow code reuse.


Additional question: we've noticed that the "tabs" indent_style setting in the .editorconfig does not match the indentation used in the code (being spaces). Which one of the two should it be?


(co-authored by @yentlprojects)