### PR TITLE
Rfc/autopush submodule branches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-indent_style = tab
+indent_style = space
 indent_size = 4
 tab_width = 4

--- a/src/main.ts
+++ b/src/main.ts
@@ -978,6 +978,9 @@ export default class ObsidianGit extends Plugin {
     }
 
     async remotesAreSet(): Promise<boolean> {
+        if(this.settings.autoPushBranch){
+            return true;
+        }
         if (!(await this.gitManager.branchInfo()).tracking) {
             new Notice("No upstream branch is set. Please select one.");
             const remoteBranch = await this.selectRemoteBranch();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -476,6 +476,19 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                                 plugin.saveSettings();
                             })
                     );
+
+                new Setting(containerEl)
+                    .setName('Match submodule branches to root branch on commit')
+                    .setDesc('Will automatically match the branch name in the submodules to the root repository branch name (if there are changes in the submodule). Creates branch if it does not exist. Use this with push.default=current for easy pushing.')
+                    .addToggle((toggle) =>
+                        toggle
+                            .setValue(plugin.settings.matchRootBranchName)
+                            .onChange((value) => {
+                                plugin.settings.matchRootBranchName = value;
+                                plugin.settings.autoPushBranch = value;
+                                plugin.saveSettings();
+                            })
+                    );
             }
         }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -452,7 +452,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
         containerEl.createEl("br");
         containerEl.createEl("h3", { text: "Advanced" });
 
-        if (plugin.gitManager instanceof SimpleGit)
+		if (plugin.gitManager instanceof SimpleGit) {
             new Setting(containerEl)
                 .setName("Update submodules")
                 .setDesc('"Create backup" and "pull" takes care of submodules. Missing features: Conflicted files, count of pulled/pushed/committed files. Tracking branch needs to be set for each submodule')
@@ -464,6 +464,21 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                             plugin.saveSettings();
                         })
                 );
+            if (plugin.settings.updateSubmodules) {
+                new Setting(containerEl)
+                    .setName('Submodule recurse checkout/switch')
+                    .setDesc('Whenever a checkout happens on the root repository, recurse the checkout on the submodules (if the branches exist).')
+                    .addToggle((toggle) =>
+                        toggle
+                            .setValue(plugin.settings.submoduleRecurseCheckout)
+                            .onChange((value) => {
+                                plugin.settings.submoduleRecurseCheckout = value;
+                                plugin.saveSettings();
+                            })
+                    );
+            }
+        }
+
 
         if (plugin.gitManager instanceof SimpleGit)
             new Setting(containerEl)

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -82,7 +82,6 @@ export class SimpleGit extends GitManager {
                 this.git.outputHandler(async (cmd, stdout, stderr, args) => {
                     // Do not run this handler on other commands
                     if (!(args.contains('submodule') && args.contains('foreach'))) {
-                        resolve([]);
                         return;
                     }
 

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -76,6 +76,45 @@ export class SimpleGit extends GitManager {
         };
     }
 
+    async getSubmodulePaths(): Promise<string[]> {
+        return new Promise<string[]>(async (resolve) => {
+            if (this.plugin.settings.submoduleRecurseCheckout) {
+                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
+                    // Do not run this handler on other commands
+                    if (!(args.contains('submodule') && args.contains('foreach'))) {
+                        resolve([]);
+                        return;
+                    }
+
+                    let body = '';
+                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? '/' + this.plugin.settings.basePath : '');
+                    stdout.on('data', (chunk) => {
+                        body += chunk.toString('utf8');
+                    });
+                    stdout.on('end', async () => {
+                        const submods = body.split('\n');
+
+                        // Remove words like `Entering` in front of each line and filter empty lines
+                        const strippedSubmods: string[] = submods.map(i => {
+                            const submod = i.match(/'([^']*)'/);
+                            if (submod != undefined) {
+                                return root + '/' + submod[ 1 ] + sep;
+                            }
+                        }).filter((i): i is string => !!i);
+
+                        strippedSubmods.reverse();
+                        resolve(strippedSubmods);
+                    });
+                });
+
+                await this.git.subModule(['foreach', '--recursive', '']);
+                this.git.outputHandler(() => {
+                });
+            }
+        });
+    }
+
+
     //Remove wrong `"` like "My file.md"
     formatPath(path: { from?: string, path: string; }, renamed = false): { path: string, from?: string; } {
         function format(path?: string): string | undefined {
@@ -102,46 +141,11 @@ export class SimpleGit extends GitManager {
     async commitAll({ message }: { message: string; }): Promise<number> {
         if (this.plugin.settings.updateSubmodules) {
             this.plugin.setState(PluginState.commit);
-            await new Promise<void>(async (resolve, reject) => {
-
-                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
-
-                    // Do not run this handler on other commands
-                    if (!(args.contains("submodule") && args.contains("foreach"))) return;
-
-                    let body = "";
-                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? "/" + this.plugin.settings.basePath : "");
-                    stdout.on('data', (chunk) => {
-                        body += chunk.toString('utf8');
-                    });
-                    stdout.on('end', async () => {
-                        const submods = body.split('\n');
-
-                        // Remove words like `Entering` in front of each line and filter empty lines
-                        const strippedSubmods = submods.map(i => {
-                            const submod = i.match(/'([^']*)'/);
-                            if (submod != undefined) {
-                                return root + "/" + submod[1] + sep;
-                            }
-                        });
-
-                        strippedSubmods.reverse();
-                        for (const item of strippedSubmods) {
-                            // Catch empty lines
-                            if (item != undefined) {
-                                await this.git.cwd({ path: item, root: false }).add("-A", (err) => this.onError(err));
-                                await this.git.cwd({ path: item, root: false }).commit(await this.formatCommitMessage(message), (err) => this.onError(err));
-                            }
-                        }
-                        resolve();
-                    });
-                });
-
-
-                await this.git.subModule(["foreach", "--recursive", '']);
-                this.git.outputHandler(() => { });
-            });
-
+            const submodulePaths = await this.getSubmodulePaths();
+            for (const item of submodulePaths) {
+                await this.git.cwd({ path: item, root: false }).add("-A", (err) => this.onError(err));
+                await this.git.cwd({ path: item, root: false }).commit(await this.formatCommitMessage(message), (err) => this.onError(err));
+            }
         }
         this.plugin.setState(PluginState.add);
 
@@ -329,47 +333,15 @@ export class SimpleGit extends GitManager {
 
     async checkout(branch: string): Promise<void> {
         await this.git.checkout(branch, (err) => this.onError(err));
-        await new Promise<void>(async (resolve, reject) => {
-            if (this.plugin.settings.submoduleRecurseCheckout) {
-                this.git.outputHandler(async (cmd, stdout, stderr, args) => {
-                    // Do not run this handler on other commands
-                    if (!(args.contains('submodule') && args.contains('foreach'))) return;
-
-                    let body = '';
-                    const root = (this.app.vault.adapter as FileSystemAdapter).getBasePath() + (this.plugin.settings.basePath ? '/' + this.plugin.settings.basePath : '');
-                    stdout.on('data', (chunk) => {
-                        body += chunk.toString('utf8');
-                    });
-                    stdout.on('end', async () => {
-                        const submods = body.split('\n');
-
-                        // Remove words like `Entering` in front of each line and filter empty lines
-                        const strippedSubmods = submods.map(i => {
-                            const submod = i.match(/'([^']*)'/);
-                            if (submod != undefined) {
-                                return root + '/' + submod[ 1 ] + sep;
-                            }
-                        });
-
-                        strippedSubmods.reverse();
-                        for (const item of strippedSubmods) {
-                            // Catch empty lines
-                            if (item != undefined) {
-                                let branchSummary = await this.git.cwd({ path: item, root: false }).branch();
-                                if (Object.keys(branchSummary.branches).includes(branch)) {
-                                    await this.git.cwd({ path: item, root: false }).checkout(branch, (err) => this.onError(err));
-                                }
-                            }
-                        }
-                        resolve();
-                    });
-                });
-
-                await this.git.subModule(['foreach', '--recursive', '']);
-                this.git.outputHandler(() => {
-                });
+        if (this.plugin.settings.submoduleRecurseCheckout) {
+            const submodulePaths = await this.getSubmodulePaths();
+            for (const submodulePath of submodulePaths) {
+                let branchSummary = await this.git.cwd({ path: submodulePath, root: false }).branch();
+                if (Object.keys(branchSummary.branches).includes(branch)) {
+                    await this.git.cwd({ path: submodulePath, root: false }).checkout(branch, (err) => this.onError(err));
+                }
             }
-        });
+        }
     }
 
     async createBranch(branch: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface ObsidianGitSettings {
     listChangedFilesInMessageBody: boolean;
     showStatusBar: boolean;
     updateSubmodules: boolean;
+	submoduleRecurseCheckout: boolean;
     /**
     * @deprecated Using `localstorage` instead
     */

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface ObsidianGitSettings {
     updateSubmodules: boolean;
 	submoduleRecurseCheckout: boolean;
 	matchRootBranchName: boolean;
+    autoPushBranch: boolean;
 	/**
     * @deprecated Using `localstorage` instead
     */

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,8 @@ export interface ObsidianGitSettings {
     showStatusBar: boolean;
     updateSubmodules: boolean;
 	submoduleRecurseCheckout: boolean;
-    /**
+	matchRootBranchName: boolean;
+	/**
     * @deprecated Using `localstorage` instead
     */
     gitPath?: string;


### PR DESCRIPTION
This PR continues on our last PR (https://github.com/denolehov/obsidian-git/pull/409). It is more of a "Request for Comments" as we would like some input on how to achieve our desired feature.

We are trying to do the following:
- Centralize documentation using a single vault for a software development team.
- Use submodules, with sparse checkouts to target a specific "docs" folder
  - This works just fine, without using cone. (not exactly relevant for this PR)
- Have the development team use feature branching/git-flow on the root repository in the Obsidian vault
  - And have changes in the submodules automatically comitted and pushed on the identically named branch as the root (without making unnecessary local branches)

This PR is a working POC. But we are finding it difficult to submit as a proper feature, as we are working around the fact that the code depends on the state of the remote (see the TODO added: https://github.com/denolehov/obsidian-git/pull/410/files#diff-84fca5244db4a641308029df3d47739e329ee540e5ccca0041ac168d5f19574eR286).

Any input on this matter would be greatly appreciated.

Kind regards,

@DenEwout / @yentlprojects