### PR TITLE
Fix splitting remote branch name

### DIFF
--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -6,7 +6,7 @@ import ObsidianGit from './main';
 import { MyAdapter } from './myAdapter';
 import { BranchInfo, FileStatusResult, PluginState, Status, UnstagedFile, WalkDifference } from "./types";
 import { GeneralModal } from "./ui/modals/generalModal";
-import { worthWalking } from "./utils";
+import { splitRemoteBranch, worthWalking } from "./utils";
 
 export class IsomorphicGit extends GitManager {
     private readonly FILE = 0;
@@ -570,7 +570,7 @@ export class IsomorphicGit extends GitManager {
     }
 
     async updateUpstreamBranch(remoteBranch: string): Promise<void> {
-        const [remote, branch] = remoteBranch.split("/");
+        const [remote, branch] = splitRemoteBranch(remoteBranch);
         const branchInfo = await this.branchInfo();
 
         await this.setConfig(`branch.${branchInfo.current}.merge`, `refs/heads/${branch}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { GeneralModal } from "./ui/modals/generalModal";
 import { IgnoreModal } from "./ui/modals/ignoreModal";
 import GitView from "./ui/sidebar/sidebarView";
 import { BranchStatusBar } from "./ui/statusBar/branchStatusBar";
-import { getNewLeaf } from "./utils";
+import { getNewLeaf, splitRemoteBranch } from "./utils";
 
 export default class ObsidianGit extends Plugin {
     gitManager: GitManager;
@@ -821,7 +821,7 @@ export default class ObsidianGit extends Plugin {
 
     async hasTooBigFiles(files: ({ vault_path: string; })[]): Promise<boolean> {
         const branchInfo = await this.gitManager.branchInfo();
-        const remote = branchInfo.tracking?.split("/")[0];
+        const remote = branchInfo.tracking ? splitRemoteBranch(branchInfo.tracking)[0] : null;
 
         if (remote) {
             const remoteUrl = await this.gitManager.getRemoteUrl(remote);
@@ -953,7 +953,7 @@ export default class ObsidianGit extends Plugin {
 
         const selectedBranch = await this.selectRemoteBranch() || '';
 
-        const [remote, branch] = selectedBranch.split("/");
+        const [remote, branch] = splitRemoteBranch(selectedBranch);
 
         if (branch != undefined && remote != undefined) {
             await this.gitManager.checkout(branch, remote);

--- a/src/simpleGit.ts
+++ b/src/simpleGit.ts
@@ -7,6 +7,7 @@ import simpleGit, { DefaultLogFields } from "simple-git";
 import { GitManager } from "./gitManager";
 import ObsidianGit from "./main";
 import { BranchInfo, FileStatusResult, PluginState, Status } from "./types";
+import { splitRemoteBranch } from "./utils";
 
 export class SimpleGit extends GitManager {
     git: simple.SimpleGit;
@@ -438,7 +439,7 @@ export class SimpleGit extends GitManager {
             } catch (e) {
                 console.error(e);
                 // fallback
-                await this.git.push(["--set-upstream", ...remoteBranch.split("/")], (err) => this.onError(err));
+                await this.git.push(["--set-upstream", ...splitRemoteBranch(remoteBranch)], (err) => this.onError(err));
             }
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ export function getNewLeaf(event?: MouseEvent): WorkspaceLeaf | undefined {
     return leaf;
 }
 
-export function splitRemoteBranch(remoteBranch: string): readonly [string, string] {
+export function splitRemoteBranch(remoteBranch: string): readonly [string | undefined, string | undefined] {
     const [remote, ...branch] = remoteBranch.split("/")
-    return [remote, branch.join("/")]
+    return [remote, branch.length === 0 ? undefined : branch.join("/")]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,8 @@ export function getNewLeaf(event?: MouseEvent): WorkspaceLeaf | undefined {
     }
     return leaf;
 }
+
+export function splitRemoteBranch(remoteBranch: string): readonly [string, string] {
+    const [remote, ...branch] = remoteBranch.split("/")
+    return [remote, branch.join("/")]
+}


### PR DESCRIPTION
This fixes handling of branches that contain `/` in their names.