### PR TITLE
Add error handlings when retrieving branch names

### DIFF
--- a/src/openInGitHub.ts
+++ b/src/openInGitHub.ts
@@ -2,7 +2,14 @@ import { Editor, Notice, TFile } from "obsidian";
 import { GitManager } from "./gitManager";
 
 export async function openLineInGitHub(editor: Editor, file: TFile, manager: GitManager) {
-    const { isGitHub, branch, repo, user } = await getData(manager);
+    const data = await getData(manager);
+
+    if (data.result === 'failure') {
+        new Notice(data.reason);
+        return;
+    }
+
+    const { isGitHub, branch, repo, user } = data;
     if (isGitHub) {
         const path = manager.getPath(file.path, true);
         const from = editor.getCursor("from").line + 1;
@@ -18,7 +25,14 @@ export async function openLineInGitHub(editor: Editor, file: TFile, manager: Git
 }
 
 export async function openHistoryInGitHub(file: TFile, manager: GitManager) {
-    const { isGitHub, branch, repo, user } = await getData(manager);
+    const data = await getData(manager);
+
+    if (data.result === 'failure') {
+        new Notice(data.reason);
+        return;
+    }
+
+    const { isGitHub, branch, repo, user } = data;
     const path = manager.getPath(file.path, true);
 
     if (isGitHub) {
@@ -28,15 +42,31 @@ export async function openHistoryInGitHub(file: TFile, manager: GitManager) {
     }
 }
 
-async function getData(manager: GitManager): Promise<{ isGitHub: boolean, user: string, repo: string; branch: string; }> {
+async function getData(manager: GitManager): Promise<{ result: 'success'; isGitHub: boolean; user: string; repo: string; branch: string; } | { result: 'failure'; reason: string; }> {
     const branchInfo = await manager.branchInfo();
     const remoteBranch = branchInfo.tracking;
     const branch = branchInfo.current;
+
+    if (remoteBranch == null) {
+        return  {
+            result: 'failure',
+            reason: 'Remote branch is not configured',
+        };
+    }
+
+    if (branch == null) {
+        return  {
+            result: 'failure',
+            reason: 'Failed to get current branch name',
+        };
+    }
+
 
     const remote = remoteBranch.substring(0, remoteBranch.indexOf("/"));
     const remoteUrl = await manager.getConfig(`remote.${remote}.url`) as string;
     const [isGitHub, httpsUser, httpsRepo, sshUser, sshRepo] = remoteUrl.match(/(?:^https:\/\/github\.com\/(.*)\/(.*)\.git$)|(?:^git@github\.com:(.*)\/(.*)\.git$)/);
     return {
+        result: 'success',
         isGitHub: !!isGitHub,
         repo: httpsRepo || sshRepo,
         user: httpsUser || sshUser,


### PR DESCRIPTION
Added error handlings when a remote branch is not configured.

Although I could not imagine a case where a remote branch name could be retrieved but not the current branch name, it could occur based on the types, so I also added.