### PR TITLE
Add discard all changes command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -383,8 +383,7 @@ export default class ObsidianGit extends Plugin {
             id: "discard-all",
             name: "CAUTION: Discard all changes",
             callback: async () => {
-                const repoExists = await this.app.vault.adapter.exists(`${this.settings.basePath}/.git`);
-                if (repoExists) {
+                if (! await this.isAllInitialized()) return false;
                     const modal = new GeneralModal({
                         options: ["NO", "YES"],
                         placeholder: "Do you want to discard all changes to tracked files? This action cannot be undone.",
@@ -394,10 +393,6 @@ export default class ObsidianGit extends Plugin {
                     if (shouldDiscardAll) {
                         this.promiseQueue.addTask(() => this.discardAll());
                     }
-
-                } else {
-                    new Notice("No repository found");
-                }
             }
         });
 
@@ -1080,7 +1075,6 @@ export default class ObsidianGit extends Plugin {
 
     async discardAll() {
         await this.gitManager.discardAll({
-            dir: '/',
             status: this.cachedStatus
         })
         new Notice('All local changes have been discarded. New files remain untouched.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -380,19 +380,19 @@ export default class ObsidianGit extends Plugin {
         });
 
         this.addCommand({
-            id: "reset-hard",
-            name: "CAUTION: Reset hard",
+            id: "discard-all",
+            name: "CAUTION: Discard all changes",
             callback: async () => {
                 const repoExists = await this.app.vault.adapter.exists(`${this.settings.basePath}/.git`);
                 if (repoExists) {
                     const modal = new GeneralModal({
                         options: ["NO", "YES"],
-                        placeholder: "Do you want to reset all changed files to the last commit? You will lose all changes to those files.",
+                        placeholder: "Do you want to discard all changes to tracked files? This action cannot be undone.",
                         onlySelection: true
                     });
-                    const shouldResetHard = await modal.open() === "YES";
-                    if (shouldResetHard) {
-                        this.promiseQueue.addTask(() => this.resetHard());
+                    const shouldDiscardAll = await modal.open() === "YES";
+                    if (shouldDiscardAll) {
+                        this.promiseQueue.addTask(() => this.discardAll());
                     }
 
                 } else {
@@ -1078,10 +1078,10 @@ export default class ObsidianGit extends Plugin {
         }
     }
 
-    async resetHard() {
+    async discardAll() {
         await this.gitManager.discardAll({
-            dir: '.',
-            status: await this.gitManager.status()
+            dir: '/',
+            status: this.cachedStatus
         })
         new Notice('All local changes have been discarded. New files remain untouched.');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -387,7 +387,7 @@ export default class ObsidianGit extends Plugin {
                 if (repoExists) {
                     const modal = new GeneralModal({
                         options: ["NO", "YES"],
-                        placeholder: "Do you want to reset all changed files to the last commit? You will lose all changes to tracked files.",
+                        placeholder: "Do you want to reset all changed files to the last commit? You will lose all changes to those files.",
                         onlySelection: true
                     });
                     const shouldResetHard = await modal.open() === "YES";


### PR DESCRIPTION
Resolving merge conflicts is pretty hard on mobile (#340) and though some workarounds exist, the workflow is not ideal, especially if you don't have access to your desktop. 

I think a quick solution would be to provide a `git reset --hard` command to allow mobile users to discard all their local changes to the last commit. They can then pull without conflicts and re-add their changes manually.

This PR adds a "Reset hard" command using the `gitManager`'s `discardAll` method

**Update:** I realized after an embarrassingly long amount of time that you can use the source control view to achieve the same effect, However I still think there's value in this command considering how common an operation this could be from the discussion in #340 