### PR TITLE
Fix diff view issue on smartphones and tablets

### DIFF
--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -758,10 +758,15 @@ export class IsomorphicGit extends GitManager {
         const stagedContent = new TextDecoder().decode(stagedBlob);
 
         if (stagedChanges) {
-            const headBlob = await readBlob({ ...this.getRepo(), filepath: filePath, oid: await this.resolveRef("HEAD") });
-            const headContent = new TextDecoder().decode(headBlob.blob);
+            const headContent: string | undefined = await this.resolveRef("HEAD")
+                .then((oid) => readBlob({ ...this.getRepo(), filepath: filePath, oid: oid }))
+                .then((headBlob) => new TextDecoder().decode(headBlob.blob))
+                .catch((err) => {
+                    if (err instanceof git.Errors.NotFoundError) return undefined;
+                    throw err;
+                });
 
-            const diff = createPatch(filePath, headContent, stagedContent);
+            const diff = createPatch(filePath, headContent ?? "", stagedContent);
             return diff;
 
         } else {

--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -972,15 +972,26 @@ export class IsomorphicGit extends GitManager {
         const stagedContent = new TextDecoder().decode(stagedBlob);
 
         if (stagedChanges) {
-            const headContent: string | undefined = await this.resolveRef("HEAD")
-                .then((oid) => readBlob({ ...this.getRepo(), filepath: filePath, oid: oid }))
+            const headContent = await this.resolveRef("HEAD")
+                .then((oid) =>
+                    readBlob({
+                        ...this.getRepo(),
+                        filepath: filePath,
+                        oid: oid,
+                    })
+                )
                 .then((headBlob) => new TextDecoder().decode(headBlob.blob))
                 .catch((err) => {
-                    if (err instanceof git.Errors.NotFoundError) return undefined;
+                    if (err instanceof git.Errors.NotFoundError)
+                        return undefined;
                     throw err;
                 });
 
-            const diff = createPatch(filePath, headContent ?? "", stagedContent);
+            const diff = createPatch(
+                filePath,
+                headContent ?? "",
+                stagedContent
+            );
             return diff;
         } else {
             let workdirContent: string;

--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -742,9 +742,9 @@ export class IsomorphicGit extends GitManager {
     }
 
     async getDiffString(filePath: string): Promise<string> {
-        const workdirContent: string | undefined = await app.vault.adapter.exists(filePath)
+        const workdirContent: string = await app.vault.adapter.exists(filePath)
             ? await app.vault.adapter.read(filePath)
-            : undefined;
+            : "";
         const headContent: string | undefined = await readBlob({
                 ...this.getRepo(),
                 filepath: filePath,
@@ -756,7 +756,7 @@ export class IsomorphicGit extends GitManager {
                 throw err;
             });
 
-        return createPatch(filePath, headContent ?? "", workdirContent ?? "");
+        return createPatch(filePath, headContent ?? "", workdirContent);
     }
 
     async getLastCommitTime(): Promise<Date | undefined> {

--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -741,22 +741,40 @@ export class IsomorphicGit extends GitManager {
 
     }
 
-    async getDiffString(filePath: string): Promise<string> {
-        const workdirContent: string = await app.vault.adapter.exists(filePath)
-            ? await app.vault.adapter.read(filePath)
-            : "";
-        const headContent: string | undefined = await readBlob({
-                ...this.getRepo(),
-                filepath: filePath,
-                oid: await this.resolveRef("HEAD"),
-            })
-            .then((headBlob) => new TextDecoder().decode(headBlob.blob))
-            .catch((err) => {
-                if (err instanceof git.Errors.NotFoundError) return undefined;
-                throw err;
-            });
+    async getDiffString(filePath: string, stagedChanges = false): Promise<string> {
+        const map: WalkerMap = async (file, [A]) => {
+            if (filePath == file) {
+                const oid = await A!.oid();
+                const contents = await git.readBlob({ ...this.getRepo(), oid: oid });
+                return contents.blob;
+            }
+        };
 
-        return createPatch(filePath, headContent ?? "", workdirContent);
+        const stagedBlob = (await git.walk({
+            ...this.getRepo(),
+            trees: [git.STAGE()],
+            map,
+        })).first();
+        const stagedContent = new TextDecoder().decode(stagedBlob);
+
+        if (stagedChanges) {
+            const headBlob = await readBlob({ ...this.getRepo(), filepath: filePath, oid: await this.resolveRef("HEAD") });
+            const headContent = new TextDecoder().decode(headBlob.blob);
+
+            const diff = createPatch(filePath, headContent, stagedContent);
+            return diff;
+
+        } else {
+            let workdirContent: string;
+            if (await app.vault.adapter.exists(filePath)) {
+                workdirContent = await app.vault.adapter.read(filePath);
+            } else {
+                workdirContent = "";
+            }
+
+            const diff = createPatch(filePath, stagedContent, workdirContent);
+            return diff;
+        }
     }
 
     async getLastCommitTime(): Promise<Date | undefined> {

--- a/src/isomorphicGit.ts
+++ b/src/isomorphicGit.ts
@@ -742,9 +742,9 @@ export class IsomorphicGit extends GitManager {
     }
 
     async getDiffString(filePath: string): Promise<string> {
-        const workdirContent: string = await app.vault.adapter.exists(filePath)
+        const workdirContent: string | undefined = await app.vault.adapter.exists(filePath)
             ? await app.vault.adapter.read(filePath)
-            : "";
+            : undefined;
         const headContent: string | undefined = await readBlob({
                 ...this.getRepo(),
                 filepath: filePath,
@@ -756,7 +756,7 @@ export class IsomorphicGit extends GitManager {
                 throw err;
             });
 
-        return createPatch(filePath, headContent ?? "", workdirContent);
+        return createPatch(filePath, headContent ?? "", workdirContent ?? "");
     }
 
     async getLastCommitTime(): Promise<Date | undefined> {


### PR DESCRIPTION
Fixes #429

This issue is caused by a `NotFoundError` that may occur when executing `readBlob`. The solution here is to catch the error and return `undefined` when that error occurs.

~~In addition I have simplified the logic by removing the `stagedChanged` argument and removing the branching by `stagedChanged`. In the end, all we want to see in the diff view is the difference from `HEAD`, so I think this is sufficient.~~