### PR TITLE
Enable `skipLibCheck` to fix CI

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
             "ES5",
             "ES6",
             "ES7"
-        ]
+        ],
+        "skipLibCheck": true
     },
     "include": [
         "**/*.ts"


### PR DESCRIPTION
Currently, the codemirror type definition file is causing compile errors and CI is failing. As an emergency workaround, I have enabled `skipLibCheck`.