### PR TITLE
Organize GitManager-related classes

### DIFF
--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,5 +1,5 @@
 import { App } from "obsidian";
-import ObsidianGit from "./main";
+import ObsidianGit from "../main";
 import {
     BranchInfo,
     DiffFile,
@@ -8,7 +8,7 @@ import {
     Status,
     TreeItem,
     UnstagedFile,
-} from "./types";
+} from "../types";
 
 export abstract class GitManager {
     readonly plugin: ObsidianGit;

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -14,7 +14,7 @@ import git, {
 import { Notice, requestUrl } from "obsidian";
 import { GitManager } from "./gitManager";
 import ObsidianGit from "../main";
-import { MyAdapter } from "../myAdapter";
+import { MyAdapter } from "./myAdapter";
 import {
     BranchInfo,
     FileStatusResult,

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -13,8 +13,8 @@ import git, {
 } from "isomorphic-git";
 import { Notice, requestUrl } from "obsidian";
 import { GitManager } from "./gitManager";
-import ObsidianGit from "./main";
-import { MyAdapter } from "./myAdapter";
+import ObsidianGit from "../main";
+import { MyAdapter } from "../myAdapter";
 import {
     BranchInfo,
     FileStatusResult,
@@ -23,9 +23,9 @@ import {
     Status,
     UnstagedFile,
     WalkDifference,
-} from "./types";
-import { GeneralModal } from "./ui/modals/generalModal";
-import { splitRemoteBranch, worthWalking } from "./utils";
+} from "../types";
+import { GeneralModal } from "../ui/modals/generalModal";
+import { splitRemoteBranch, worthWalking } from "../utils";
 
 export class IsomorphicGit extends GitManager {
     private readonly FILE = 0;

--- a/src/gitManager/myAdapter.ts
+++ b/src/gitManager/myAdapter.ts
@@ -1,5 +1,5 @@
 import { DataAdapter, normalizePath, TFile, Vault } from "obsidian";
-import ObsidianGit from "./main";
+import ObsidianGit from "../main";
 
 export class MyAdapter {
     promises: any = {};

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -5,15 +5,15 @@ import * as path from "path";
 import { sep } from "path";
 import simpleGit, * as simple from "simple-git";
 import { GitManager } from "./gitManager";
-import ObsidianGit from "./main";
+import ObsidianGit from "../main";
 import {
     BranchInfo,
     FileStatusResult,
     LogEntry,
     PluginState,
     Status,
-} from "./types";
-import { splitRemoteBranch } from "./utils";
+} from "../types";
+import { splitRemoteBranch } from "../utils";
 
 export class SimpleGit extends GitManager {
     git: simple.SimpleGit;

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,11 +24,11 @@ import {
     HISTORY_VIEW_CONFIG,
     SOURCE_CONTROL_VIEW_CONFIG,
 } from "./constants";
-import { GitManager } from "./gitManager";
-import { IsomorphicGit } from "./isomorphicGit";
+import { GitManager } from "./gitManager/gitManager";
+import { IsomorphicGit } from "./gitManager/isomorphicGit";
 import { LocalStorageSettings } from "./localStorageSettings";
 import { openHistoryInGitHub, openLineInGitHub } from "./openInGitHub";
-import { SimpleGit } from "./simpleGit";
+import { SimpleGit } from "./gitManager/simpleGit";
 import {
     FileStatusResult,
     ObsidianGitSettings,

--- a/src/openInGitHub.ts
+++ b/src/openInGitHub.ts
@@ -1,5 +1,5 @@
 import { Editor, Notice, TFile } from "obsidian";
-import { GitManager } from "./gitManager";
+import { GitManager } from "./gitManager/gitManager";
 
 export async function openLineInGitHub(
     editor: Editor,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 import { Notice, Platform, PluginSettingTab, Setting } from "obsidian";
-import { IsomorphicGit } from "./isomorphicGit";
+import { IsomorphicGit } from "./gitManager/isomorphicGit";
 import ObsidianGit from "./main";
-import { SimpleGit } from "./simpleGit";
+import { SimpleGit } from "./gitManager/simpleGit";
 import { SyncMethod } from "./types";
 
 export class ObsidianGitSettingsTab extends PluginSettingTab {

--- a/src/ui/history/historyView.svelte
+++ b/src/ui/history/historyView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { setIcon } from "obsidian";
     import ObsidianGit from "src/main";
-    import { SimpleGit } from "src/simpleGit";
+    import { SimpleGit } from "src/gitManager/simpleGit";
     import { LogEntry } from "src/types";
     import { onDestroy } from "svelte";
     import LogComponent from "./components/logComponent.svelte";

--- a/src/ui/sourceControl/components/fileComponent.svelte
+++ b/src/ui/sourceControl/components/fileComponent.svelte
@@ -2,7 +2,7 @@
     import { setIcon, TFile } from "obsidian";
     import { hoverPreview } from "obsidian-community-lib";
     import { DIFF_VIEW_CONFIG } from "src/constants";
-    import { GitManager } from "src/gitManager";
+    import { GitManager } from "src/gitManager/gitManager";
     import { FileStatusResult } from "src/types";
     import { DiscardModal } from "src/ui/modals/discardModal";
     import { getDisplayPath, getNewLeaf } from "src/utils";

--- a/src/ui/sourceControl/components/stagedFileComponent.svelte
+++ b/src/ui/sourceControl/components/stagedFileComponent.svelte
@@ -2,7 +2,7 @@
     import { setIcon, TFile } from "obsidian";
     import { hoverPreview } from "obsidian-community-lib";
     import { DIFF_VIEW_CONFIG } from "src/constants";
-    import { GitManager } from "src/gitManager";
+    import { GitManager } from "src/gitManager/gitManager";
     import { FileStatusResult } from "src/types";
     import { getDisplayPath, getNewLeaf } from "src/utils";
     import GitView from "../sourceControl";


### PR DESCRIPTION
To group related classes together and improve readability, I moved GitManager, its child classes, and MyAdapter, which is used inside the IsomorphicGit class, under `gitManager/`.