### PR TITLE
Enable `noUncheckedIndexedAccess` option

### DIFF
--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -242,7 +242,7 @@ export abstract class GitManager {
             const changeset: { [key: string]: string[] } = {};
             status.staged.forEach((value: FileStatusResult) => {
                 if (value.index in changeset) {
-                    changeset[value.index].push(value.path);
+                    changeset[value.index]!.push(value.path);
                 } else {
                     changeset[value.index] = [value.path];
                 }

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -774,7 +774,7 @@ export class IsomorphicGit extends GitManager {
                 const completeMessage = log.commit.message.split("\n\n");
 
                 return {
-                    message: completeMessage[0],
+                    message: completeMessage[0]!,
                     body: completeMessage.slice(1).join("\n\n"),
                     date: new Date(
                         log.commit.committer.timestamp

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -56,7 +56,7 @@ export class SimpleGit extends GitManager {
             }
             for (const envVar of envVars) {
                 const [key, value] = envVar.split("=");
-                process.env[key] = value;
+                process.env[key!] = value;
             }
 
             debug.enable("simple-git");
@@ -579,7 +579,7 @@ export class SimpleGit extends GitManager {
 
         const list = [];
         for (const item in res.branches) {
-            list.push(res.branches[item].name);
+            list.push(res.branches[item]!.name);
         }
         return list;
     }

--- a/src/promiseQueue.ts
+++ b/src/promiseQueue.ts
@@ -9,7 +9,7 @@ export class PromiseQueue {
     }
     async handleTask() {
         if (this.tasks.length > 0) {
-            this.tasks[0]().finally(() => {
+            this.tasks[0]!().finally(() => {
                 this.tasks.shift();
                 this.handleTask();
             });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function splitRemoteBranch(
     remoteBranch: string
 ): readonly [string, string | undefined] {
     const [remote, ...branch] = remoteBranch.split("/");
-    return [remote, branch.length === 0 ? undefined : branch.join("/")];
+    return [remote!, branch.length === 0 ? undefined : branch.join("/")];
 }
 
 export function getDisplayPath(path: string): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "moduleResolution": "node",
         "strictNullChecks": true,
         "importHelpers": true,
+        "noUncheckedIndexedAccess": true,
         "lib": [
             "DOM",
             "ES5",


### PR DESCRIPTION
To make development safer, I have enabled `noUncheckedIndexedAccess` option in TypeScript. This reduces the risk of runtime errors during array access.

As a result, several of the existing logic resulted in type errors, but since we need to be cautious about fundamentally fixing them, I made a workaround in this pull request by adding non-null assertions.