### PR TITLE
Update release template to use softprops/action-gh-release with release notes generations

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,6 +8,9 @@ on:
 env:
     PLUGIN_NAME: obsidian-git
 
+permissions:
+  contents: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -29,16 +32,13 @@ jobs:
                   cp main.js manifest.json ${{ env.PLUGIN_NAME }}
                   zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
                   ls
-                  echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
             - name: Create Release
               id: create_release
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  VERSION: ${{ github.ref }}
+              uses: softprops/action-gh-release@v1
               with:
                   tag_name: ${{ github.ref }}
-                  release_name: ${{ github.ref }}
+                  name: ${{ github.ref_name }}
+                  generate_release_notes: true
                   draft: false
                   prerelease: false
             - name: Upload zip file
@@ -49,7 +49,7 @@ jobs:
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
                   asset_path: ./${{ env.PLUGIN_NAME }}.zip
-                  asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
+                  asset_name: ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip
                   asset_content_type: application/zip
             - name: Upload main.js
               id: upload-main


### PR DESCRIPTION
Hi,

Update release template to use softprops/action-gh-release as actions/create-release is deprecated with release notes generations.

1. Update the release workflow from actions/create-release to softprops/action-gh-release, as former is deprecated by now.
2. Add release notes auto generation during release creation, example: https://github.com/peterzhu1992/obsidian-git/releases/tag/1.0.6-test
3. Simplify the tag name retrieval and remove the deprecated set-output.

Thanks.
