### PR TITLE
make visible (secret/hidden?) `{{files}}` variable in settings

### DIFF
--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -257,7 +257,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 .setName("Commit message on auto backup/commit")
                 .setDesc(
                     "Available placeholders: {{date}}" +
-                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit), {{files}} (changed files in commit message)"
+                        " (see below), {{hostname}} (see below), {{numFiles}} (number of changed files in the commit) and {{files}} (changed files in commit message)"
                 )
                 .addText((text) =>
                     text
@@ -276,7 +276,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 .setName("Commit message on manual backup/commit")
                 .setDesc(
                     "Available placeholders: {{date}}" +
-                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit), {{files}} (changed files in commit message)"
+                        " (see below), {{hostname}} (see below), {{numFiles}} (number of changed files in the commit) and {{files}} (changed files in commit message)"
                 )
                 .addText((text) =>
                     text

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -257,7 +257,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 .setName("Commit message on auto backup/commit")
                 .setDesc(
                     "Available placeholders: {{date}}" +
-                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit)"
+                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit), {{files}} (changed files in commit message)"
                 )
                 .addText((text) =>
                     text
@@ -276,7 +276,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 .setName("Commit message on manual backup/commit")
                 .setDesc(
                     "Available placeholders: {{date}}" +
-                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit)"
+                        " (see below), {{hostname}} (see below) and {{numFiles}} (number of changed files in the commit), {{files}} (changed files in commit message)"
                 )
                 .addText((text) =>
                     text


### PR DESCRIPTION
make visible `{{files}}` variable in settings

so also non-developers (or persons without having to read the code) could use it.

Personaly I was reading the code to add this feature but it turned out it's already there, just was not mentionend :D 

I find it very useful;) 