### PR TITLE
fix: error caused by empty commit

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -554,13 +554,13 @@ export class SimpleGit extends GitManager {
             refs: e.refs.split(", "),
             diff: {
                 ...e.diff!,
-                files: e.diff!.files.map((f) => ({
+                files: e.diff ? e.diff.files.map((f) => ({
                     ...f,
                     status: f.status!,
                     path: f.file,
                     hash: e.hash,
                     vault_path: this.getVaultPath(f.file),
-                })),
+                })) : [],
             },
             fileName: e.diff?.files.first()?.file,
         }));


### PR DESCRIPTION
If git has an empty commit, it will cause error in `history`.
I created a repository to reproduce this issue. https://github.com/XiongAmao/ob-git-plugin-issue

![Snipaste_2023-07-08_13-10-19](https://github.com/denolehov/obsidian-git/assets/25665423/5e8b1940-7ea1-4241-a717-acb75af93f80)

