### PR TITLE
Adjust git.cwd to use a relative path to git root

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "child_process";
 import debug from "debug";
 import { FileSystemAdapter, normalizePath, Notice } from "obsidian";
 import * as path from "path";
-import { sep } from "path";
+import { sep, resolve } from "path";
 import simpleGit, * as simple from "simple-git";
 import { GIT_LINE_AUTHORING_MOVEMENT_DETECTION_MINIMAL_LENGTH } from "src/constants";
 import { LineAuthorFollowMovement } from "src/lineAuthor/model";
@@ -65,8 +65,11 @@ export class SimpleGit extends GitManager {
 
             debug.enable("simple-git");
             if (await this.git.checkIsRepo()) {
+                // Resolve the relative root reported by git into an absolute path
+                // in case git resides in a different filesystem (eg, WSL)
                 const relativeRoot = await this.git.revparse("--show-cdup");
-                relativeRoot && (await this.git.cwd(relativeRoot));
+                const absoluteRoot = resolve(basePath + sep + relativeRoot);
+                await this.git.cwd(absoluteRoot);
             }
         }
     }

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -66,7 +66,7 @@ export class SimpleGit extends GitManager {
             debug.enable("simple-git");
             if (await this.git.checkIsRepo()) {
                 const relativeRoot = await this.git.revparse("--show-cdup");
-                relativeRoot && await this.git.cwd(relativeRoot);
+                relativeRoot && (await this.git.cwd(relativeRoot));
             }
         }
     }

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -65,7 +65,8 @@ export class SimpleGit extends GitManager {
 
             debug.enable("simple-git");
             if (await this.git.checkIsRepo()) {
-                await this.git.cwd(await this.git.revparse("--show-toplevel"));
+                const relativeRoot = await this.git.revparse("--show-cdup");
+                relativeRoot && await this.git.cwd(relativeRoot);
             }
         }
     }


### PR DESCRIPTION
This is a simple adjustment for the git cwd command to use a relative path to the git root instead of an absolute path. It should keep the behavior identical, but it solves an issue I ran into in my setup (described below).

More details on `--show-cdup` vs `--show-toplevel` here:
https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-cdup

Motivation:
I ran into this issue during my esoteric obsidian-git setup using WSL2 (following the solution in #141). Basically, I want to use WSL's git instead of native windows `git.exe`, since I set it up with `git-crypt` and it has my ssh credentials. I ran into the issue that in this case, `git.revparse("--show-toplevel")` will return the root as an absolute WSL path (eg, `/mnt/c/Users/...`). `git.cwd()` checks path existence prior to actually switching the working directory, but does so using `fs` - which will be using the windows filesystem instead, and, of course, not find the root directory, and throw an error.

A quick solution is to pass a relative path to `git.cwd()` instead of an absolute path, as those will work the same way in WSL and Windows filesystems for a given repo. This is exactly what the `--show-cdup` flag returns. Note that it will be an empty string if we are already at the repo root, hence the additional existence check.

Some sources for my deep dive:

https://github.com/steveukx/git-js/blob/d64b31ca8670edd7af5a7fe5658516f5717c79a8/simple-git/src/lib/tasks/change-working-directory.ts#L7
https://github.com/steveukx/git-js/blob/d64b31ca8670edd7af5a7fe5658516f5717c79a8/simple-git/src/lib/utils/util.ts#L74
https://github.com/kwsites/file-exists/blob/13f0789cbd8df52588acdd185cd33de3b77fb342/src/index.ts#L10C13-L10C18
