### PR TITLE
feat: add setting for maximum number of files to display

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const DEFAULT_SETTINGS: Omit<ObsidianGitSettings, "autoCommitMessage"> =
         changedFilesInStatusBar: false,
         showedMobileNotice: false,
         refreshSourceControlTimer: 7000,
+        maximumNumberOfFilesToDisplay: 500,
         showBranchStatusBar: true,
         setLastSaveToLastCommit: false,
         submoduleRecurseCheckout: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -476,7 +476,7 @@ export default class ObsidianGit extends Plugin {
 
                 const status = await this.gitManager.status();
                 this.setState(PluginState.idle);
-                if (status.changed.length + status.staged.length > 500) {
+                if (status.changed.length + status.staged.length > this.settings.maximumNumberOfFilesToDisplay) {
                     this.displayError("Too many changes to display");
                     return;
                 }

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -451,6 +451,25 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
+            .setName("Maximum number of files displayed")
+            .setDesc(
+                "Maximum number of files displayed in the Source Control View. If there are more files than the specified number, a corresponding notification will be displayed."
+            )
+            .addText((text) =>
+                text
+                    .setValue(String(plugin.settings.maximumNumberOfFilesToDisplay))
+                    .onChange((value) => {
+                        if (!isNaN(Number(value))) {
+                            plugin.settings.maximumNumberOfFilesToDisplay = Number(value);
+                            plugin.saveSettings();
+                            plugin.refresh();
+                        } else {
+                            new Notice("Please specify a valid number.");
+                        }
+                    })
+            );
+
+        new Setting(containerEl)
             .setName("Disable notifications")
             .setDesc(
                 "Disable notifications for git operations to minimize distraction (refer to status bar for updates). Errors are still shown as notifications even if you enable this setting"

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface ObsidianGitSettings {
     basePath: string;
     showedMobileNotice: boolean;
     refreshSourceControlTimer: number;
+    maximumNumberOfFilesToDisplay: number;
     showBranchStatusBar: boolean;
     lineAuthor: LineAuthorSettings;
     setLastSaveToLastCommit: boolean;

--- a/src/ui/sourceControl/sourceControl.svelte
+++ b/src/ui/sourceControl/sourceControl.svelte
@@ -99,6 +99,10 @@
         const unPushedCommits = await plugin.gitManager.getUnpushedCommits();
 
         buttons.forEach((btn) => {
+            if (!btn) {
+                return;
+            }
+
             if (Platform.isMobile) {
                 btn.removeClass("button-border");
                 if (btn.id == "push" && unPushedCommits > 0) {
@@ -138,7 +142,7 @@
             };
             status.changed.sort(sort);
             status.staged.sort(sort);
-            if (status.changed.length + status.staged.length > 500) {
+            if (status.changed.length + status.staged.length > plugin.settings.maximumNumberOfFilesToDisplay) {
                 status = undefined;
                 if (!plugin.loading) {
                     plugin.displayError("Too many changes to display");


### PR DESCRIPTION
Hi!

I was working with Obsidian Git in big repository with a lot of notes. Got `Too many changes to display` error too often and was forced to use external VCS tool. Then I looked at the source code of this plugin and find out, that the limit is `500` and there is no setting to change that. So I add new setting `maximumNumberOfFilesToDisplay` with default value `500`. Hope I did it right!

Also, I noticed that when the value of this new setting is reduced to the error `Too many files changes` (when `refresh()` is called), then an error in console `Uncaught (in promise) TypeError: Cannot read properties of null (reading 'firstElementChild')` occurs: 

![image](https://github.com/denolehov/obsidian-git/assets/70556725/0813e291-f4b7-4b37-a338-0077321b07ae)

So I add `if (!btn) { return; }` for that to `refresh()` method in `sourceControl.svelte`.