### PR TITLE
Remove redundant awaits

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1389,7 +1389,7 @@ export default class ObsidianGit extends Plugin {
         }
 
         if (!this.timeoutIDBackup && !this.onFileModifyEventRef) {
-            const lastAutos = await this.loadLastAuto();
+            const lastAutos = this.loadLastAuto();
 
             if (this.settings.autoSaveInterval > 0) {
                 const now = new Date();
@@ -1406,7 +1406,7 @@ export default class ObsidianGit extends Plugin {
 
     async setUpAutos() {
         this.setUpAutoBackup();
-        const lastAutos = await this.loadLastAuto();
+        const lastAutos = this.loadLastAuto();
 
         if (
             this.settings.differentIntervalCommitAndPush &&


### PR DESCRIPTION
Since the return type of `this.loadLastAuto()` is non-promise, these awaits are redundant. So this pull request removes them.