### PR TITLE
Simplify expression with `!`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1706,7 +1706,7 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
                 );
             } else if (
                 sourceControlLeaf &&
-                leaf.view.state.staged === false &&
+                !leaf.view.state.staged &&
                 !leaf.view.state.hash
             ) {
                 el = sourceControlLeaf.view.containerEl.querySelector(


### PR DESCRIPTION
Since `leaf.view.state.staged` is of type boolean, the logical negation operator `!` simplifies the expression. 