### PR TITLE
fix: grammar improvement in settings

### DIFF
--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -504,7 +504,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName("Show changes files count in status bar")
+            .setName("Show the count of modified files in the status bar")
             .addToggle((toggle) =>
                 toggle
                     .setValue(plugin.settings.changedFilesInStatusBar)


### PR DESCRIPTION
Grammatical improvement in settings.
Under miscellaneous, changed "Show changes files count in status bar" to "Show the count of modified files in the status bar"