### PR TITLE
refactor: Use boolean values for `getConflict()` and `setConflict()`

### DIFF
--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -204,8 +204,7 @@ export class IsomorphicGit extends GitManager {
             await this.checkAuthorInfo();
             this.plugin.setState(PluginState.commit);
             const formatMessage = await this.formatCommitMessage(message);
-            const hadConflict =
-                this.plugin.localStorage.getConflict() === "true";
+            const hadConflict = this.plugin.localStorage.getConflict();
             let parent: string[] | undefined = undefined;
 
             if (hadConflict) {
@@ -220,7 +219,7 @@ export class IsomorphicGit extends GitManager {
                     parent: parent,
                 })
             );
-            this.plugin.localStorage.setConflict("false");
+            this.plugin.localStorage.setConflict(false);
             return;
         } catch (error) {
             this.plugin.displayError(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1004,7 +1004,7 @@ export default class ObsidianGit extends Plugin {
     }): Promise<boolean> {
         if (!(await this.isAllInitialized())) return false;
 
-        let hadConflict = this.localStorage.getConflict() === "true";
+        let hadConflict = this.localStorage.getConflict();
 
         let changedFiles: { vault_path: string }[];
         let status: Status | undefined;
@@ -1016,7 +1016,7 @@ export default class ObsidianGit extends Plugin {
 
             //Should not be necessary, but just in case
             if (status.conflicted.length == 0) {
-                this.localStorage.setConflict("false");
+                this.localStorage.setConflict(false);
                 hadConflict = false;
             }
 
@@ -1106,7 +1106,7 @@ export default class ObsidianGit extends Plugin {
             //Handle resolved conflict after commit
             if (this.gitManager instanceof SimpleGit) {
                 if ((await this.updateCachedStatus()).conflicted.length == 0) {
-                    this.localStorage.setConflict("false");
+                    this.localStorage.setConflict(false);
                 }
             }
 
@@ -1169,7 +1169,7 @@ export default class ObsidianGit extends Plugin {
         if (!(await this.remotesAreSet())) {
             return false;
         }
-        const hadConflict = this.localStorage.getConflict() === "true";
+        const hadConflict = this.localStorage.getConflict();
         if (this.gitManager instanceof SimpleGit)
             await this.mayDeleteConflictFile();
 
@@ -1550,7 +1550,7 @@ export default class ObsidianGit extends Plugin {
     async handleConflict(conflicted?: string[]): Promise<void> {
         this.setState(PluginState.conflicted);
 
-        this.localStorage.setConflict("true");
+        this.localStorage.setConflict(true);
         let lines: string[] | undefined;
         if (conflicted !== undefined) {
             lines = [

--- a/src/setting/localStorageSettings.ts
+++ b/src/setting/localStorageSettings.ts
@@ -54,12 +54,12 @@ export class LocalStorageSettings {
         return app.saveLocalStorage(this.prefix + "hostname", value);
     }
 
-    getConflict(): string | null {
-        return app.loadLocalStorage(this.prefix + "conflict");
+    getConflict(): boolean {
+        return app.loadLocalStorage(this.prefix + "conflict") == "true";
     }
 
-    setConflict(value: string): void {
-        return app.saveLocalStorage(this.prefix + "conflict", value);
+    setConflict(value: boolean): void {
+        return app.saveLocalStorage(this.prefix + "conflict", `${value}`);
     }
 
     getLastAutoPull(): string | null {


### PR DESCRIPTION
Refactors `getConflict()` and `setConflict()` to use boolean values instead of strings, similar to `getPluginDisabled()` and `setPluginDisabled()`.