### PR TITLE
Added setting to disable 'No changes...' popups

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const DEFAULT_SETTINGS: Omit<ObsidianGitSettings, "autoCommitMessage"> =
         disablePush: false,
         pullBeforePush: true,
         disablePopups: false,
+        disablePopupsForNoChanges: false,
         listChangedFilesInMessageBody: false,
         showStatusBar: true,
         updateSubmodules: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1728,8 +1728,10 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
         this.statusBar?.displayMessage(message.toLowerCase(), timeout);
 
         if (!this.settings.disablePopups) {
-            if (!this.settings.disablePopupsForNoChanges
-                || !message.startsWith("No changes")) {
+            if (
+                !this.settings.disablePopupsForNoChanges ||
+                !message.startsWith("No changes")
+            ) {
                 new Notice(message, 5 * 1000);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1728,7 +1728,11 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
         this.statusBar?.displayMessage(message.toLowerCase(), timeout);
 
         if (!this.settings.disablePopups) {
-            new Notice(message, 5 * 1000);
+            if (!this.settings.disablePopupsForNoChanges
+                || (this.settings.disablePopupsForNoChanges
+                && !message.startsWith("No changes"))) {
+                new Notice(message, 5 * 1000);
+            }
         }
 
         console.log(`git obsidian message: ${message}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1729,8 +1729,7 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
 
         if (!this.settings.disablePopups) {
             if (!this.settings.disablePopupsForNoChanges
-                || (this.settings.disablePopupsForNoChanges
-                && !message.startsWith("No changes"))) {
+                || !message.startsWith("No changes")) {
                 new Notice(message, 5 * 1000);
             }
         }

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -476,19 +476,19 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             );
 
         if (!plugin.settings.disablePopups)
-        new Setting(containerEl)
-            .setName("Hide notifications for no changes")
-            .setDesc(
-                "Don't show notifications when there are no changes to commit/push"
-            )
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(plugin.settings.disablePopupsForNoChanges)
-                    .onChange((value) => {
-                        plugin.settings.disablePopupsForNoChanges = value;
-                        plugin.saveSettings();
-                    })
-            );
+            new Setting(containerEl)
+                .setName("Hide notifications for no changes")
+                .setDesc(
+                    "Don't show notifications when there are no changes to commit/push"
+                )
+                .addToggle((toggle) =>
+                    toggle
+                        .setValue(plugin.settings.disablePopupsForNoChanges)
+                        .onChange((value) => {
+                            plugin.settings.disablePopupsForNoChanges = value;
+                            plugin.saveSettings();
+                        })
+                );
 
         new Setting(containerEl)
             .setName("Show status bar")

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -470,6 +470,22 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     .setValue(plugin.settings.disablePopups)
                     .onChange((value) => {
                         plugin.settings.disablePopups = value;
+                        this.display();
+                        plugin.saveSettings();
+                    })
+            );
+
+        if (!plugin.settings.disablePopups)
+        new Setting(containerEl)
+            .setName("Hide notifications for no changes")
+            .setDesc(
+                "Don't show notifications when there are no changes to commit/push"
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(plugin.settings.disablePopupsForNoChanges)
+                    .onChange((value) => {
+                        plugin.settings.disablePopupsForNoChanges = value;
                         plugin.saveSettings();
                     })
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface ObsidianGitSettings {
     disablePush: boolean;
     pullBeforePush: boolean;
     disablePopups: boolean;
+    disablePopupsForNoChanges: boolean;
     listChangedFilesInMessageBody: boolean;
     showStatusBar: boolean;
     updateSubmodules: boolean;


### PR DESCRIPTION
When notifications aren't disabled this new setting will be displayed. Enabling this setting, will prevent the "No changes to push" and "No changes to commit" messages from displaying. This doesn't prevent
these notifications from appearing in the status bar.

Adds feature to resolve #675