### PR TITLE
Prevent text superposing git blame

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -511,7 +511,7 @@
     white-space: pre; /* Keep spaces and do not collapse them. */
 }
 
-@media(max-width:1000px){
+@media(max-width:800px){
     /* hide git blame gutter not to superpose text */
     .cm-gutterElement.obs-git-blame-gutter {
         display: none;

--- a/styles.css
+++ b/styles.css
@@ -510,3 +510,10 @@
     padding: 0px 6px 0px 6px;
     white-space: pre; /* Keep spaces and do not collapse them. */
 }
+
+@media(max-width:1000px){
+    /* hide git blame gutter not to superpose text */
+    .cm-gutterElement.obs-git-blame-gutter {
+        display: none;
+    }
+}


### PR DESCRIPTION
Change to prevent git blame gutter from superposing text in smaller screens. There is no change for screens larger than 1000px
Before:
![image](https://github.com/denolehov/obsidian-git/assets/70990141/be0afe4b-fcb5-43fc-be33-3319036e74de)

After:
![image](https://github.com/denolehov/obsidian-git/assets/70990141/fc166cc9-dec1-4475-81f7-09875025671a)

Before and After for larger screens:
![image](https://github.com/denolehov/obsidian-git/assets/70990141/2ff06569-8f3f-45eb-9e72-c8e6ae5912db)