### PR TITLE
fix(mobile): resolve push hanging

### DIFF
--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -489,8 +489,16 @@ export class IsomorphicGit extends GitManager {
             const status = await this.branchInfo();
             const trackingBranch = status.tracking;
             const currentBranch = status.current;
+
+            if (trackingBranch == null || currentBranch == null) {
+                return 0;
+            }
+
+            const localCommit = await this.resolveRef(currentBranch);
+            const upstreamCommit = await this.resolveRef(trackingBranch);
+
             const numChangedFiles = (
-                await this.getFileChangesCount(currentBranch!, trackingBranch!)
+                await this.getFileChangesCount(localCommit, upstreamCommit)
             ).length;
 
             this.plugin.setState(PluginState.push);


### PR DESCRIPTION
ref: https://github.com/denolehov/obsidian-git/issues/609 https://github.com/denolehov/obsidian-git/issues/574

`async push()` for mobile is implemented using `this.branchInfo()`, but this branch info should be converted to latest commit hash.