### PR TITLE
fix: getRelativeRepoPath for the case of vault-inside-repo

### DIFF
--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,4 +1,4 @@
-import { App, FileSystemAdapter } from "obsidian";
+import { App, FileSystemAdapter, Platform } from "obsidian";
 import ObsidianGit from "../main";
 import * as path from 'path';
 import {
@@ -124,6 +124,10 @@ export abstract class GitManager {
     // @param doConversion - If false, the path is returned as is. This is added because that parameter is often passed on to functions where this method is called.
     getRelativeRepoPath(path_str: string, doConversion: boolean = true): string {
         if (doConversion) {
+            if (Platform.isMobileApp && this.plugin.settings.basePath.length > 0) {
+                //Expect the case that the git repository is located inside the vault on mobile platform currently.
+                return path_str.substring(this.plugin.settings.basePath.length + 1);
+            }
             let adapter = this.plugin.app.vault.adapter;
             if (adapter instanceof FileSystemAdapter) {
                 const folder = adapter.getBasePath();

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,6 +1,6 @@
 import { App, FileSystemAdapter, Platform } from "obsidian";
 import ObsidianGit from "../main";
-import * as path from 'path';
+import * as path from "path";
 import {
     BranchInfo,
     DiffFile,
@@ -122,13 +122,21 @@ export abstract class GitManager {
     // Constructs a path relative to the git repository from a path relative to the vault
     //
     // @param doConversion - If false, the path is returned as is. This is added because that parameter is often passed on to functions where this method is called.
-    getRelativeRepoPath(path_str: string, doConversion: boolean = true): string {
+    getRelativeRepoPath(
+        path_str: string,
+        doConversion: boolean = true
+    ): string {
         if (doConversion) {
-            if (Platform.isMobileApp && this.plugin.settings.basePath.length > 0) {
+            if (
+                Platform.isMobileApp &&
+                this.plugin.settings.basePath.length > 0
+            ) {
                 //Expect the case that the git repository is located inside the vault on mobile platform currently.
-                return path_str.substring(this.plugin.settings.basePath.length + 1);
+                return path_str.substring(
+                    this.plugin.settings.basePath.length + 1
+                );
             }
-            let adapter = this.plugin.app.vault.adapter;
+            const adapter = this.plugin.app.vault.adapter;
             if (adapter instanceof FileSystemAdapter) {
                 const folder = adapter.getBasePath();
                 const from = path.join(folder, this.plugin.settings.basePath);

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -123,28 +123,18 @@ export abstract class GitManager {
     //
     // @param doConversion - If false, the path is returned as is. This is added because that parameter is often passed on to functions where this method is called.
     getRelativeRepoPath(
-        path_str: string,
+        filePath: string,
         doConversion: boolean = true
     ): string {
         if (doConversion) {
-            if (
-                Platform.isMobileApp &&
-                this.plugin.settings.basePath.length > 0
-            ) {
+            if (this.plugin.settings.basePath.length > 0) {
                 //Expect the case that the git repository is located inside the vault on mobile platform currently.
-                return path_str.substring(
+                return filePath.substring(
                     this.plugin.settings.basePath.length + 1
                 );
             }
-            const adapter = this.plugin.app.vault.adapter;
-            if (adapter instanceof FileSystemAdapter) {
-                const folder = adapter.getBasePath();
-                const from = path.join(folder, this.plugin.settings.basePath);
-                const to = path.join(folder, path_str);
-                return path.relative(from, to);
-            }
         }
-        return path_str;
+        return filePath;
     }
 
     private _getTreeStructure<T = DiffFile | FileStatusResult>(

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,5 +1,6 @@
-import { App } from "obsidian";
+import { App, FileSystemAdapter } from "obsidian";
 import ObsidianGit from "../main";
+import { relative, join } from 'path';
 import {
     BranchInfo,
     DiffFile,
@@ -123,8 +124,12 @@ export abstract class GitManager {
     // @param doConversion - If false, the path is returned as is. This is added because that parameter is often passed on to functions where this method is called.
     getRelativeRepoPath(path: string, doConversion: boolean = true): string {
         if (doConversion) {
-            if (this.plugin.settings.basePath.length > 0) {
-                return path.substring(this.plugin.settings.basePath.length + 1);
+            let adapter = this.plugin.app.vault.adapter;
+            if (adapter instanceof FileSystemAdapter) {
+                const folder = adapter.getBasePath();
+                const from = join(folder, this.plugin.settings.basePath);
+                const to = join(folder, path);
+                return relative(from, to);
             }
         }
         return path;

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,6 +1,6 @@
 import { App, FileSystemAdapter } from "obsidian";
 import ObsidianGit from "../main";
-import { relative, join } from 'path';
+import * as path from 'path';
 import {
     BranchInfo,
     DiffFile,
@@ -122,17 +122,17 @@ export abstract class GitManager {
     // Constructs a path relative to the git repository from a path relative to the vault
     //
     // @param doConversion - If false, the path is returned as is. This is added because that parameter is often passed on to functions where this method is called.
-    getRelativeRepoPath(path: string, doConversion: boolean = true): string {
+    getRelativeRepoPath(path_str: string, doConversion: boolean = true): string {
         if (doConversion) {
             let adapter = this.plugin.app.vault.adapter;
             if (adapter instanceof FileSystemAdapter) {
                 const folder = adapter.getBasePath();
-                const from = join(folder, this.plugin.settings.basePath);
-                const to = join(folder, path);
-                return relative(from, to);
+                const from = path.join(folder, this.plugin.settings.basePath);
+                const to = path.join(folder, path_str);
+                return path.relative(from, to);
             }
         }
-        return path;
+        return path_str;
     }
 
     private _getTreeStructure<T = DiffFile | FileStatusResult>(

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,6 +1,5 @@
-import { App, FileSystemAdapter, Platform } from "obsidian";
+import { App } from "obsidian";
 import ObsidianGit from "../main";
-import * as path from "path";
 import {
     BranchInfo,
     DiffFile,

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -788,11 +788,11 @@ export class SimpleGit extends GitManager {
         }
     }
 
-    updateGitPath(gitPath: string) {
+    updateGitPath(_: string) {
         this.setGitInstance();
     }
 
-    updateBasePath(basePath: string) {
+    updateBasePath(_: string) {
         this.setGitInstance(true);
     }
 


### PR DESCRIPTION
This fixes #660.

Currently, `getRelativeRepoPath` considers only the case of git repository is located inside the vault.
If the vault is inside a subdirectory of git repository (this is a common case when you are using a self-host publishing system like [Quartz](https://github.com/jackyzha0/quartz)), line authoring feature won't work.

This code resolves the relative path between git repo and vault using `path` library.

