### PR TITLE
chore: Remove unnecessary `@ts-ignore`

### DIFF
--- a/src/ui/history/historyView.ts
+++ b/src/ui/history/historyView.ts
@@ -1,9 +1,6 @@
 import { HoverParent, HoverPopover, ItemView, WorkspaceLeaf } from "obsidian";
 import { HISTORY_VIEW_CONFIG } from "src/constants";
 import ObsidianGit from "src/main";
-// @tsconfig/svelte is required to resolve this error.
-// Ignore temporarily.
-// @ts-ignore
 import HistoryViewComponent from "./historyView.svelte";
 
 export default class HistoryView extends ItemView implements HoverParent {

--- a/src/ui/sourceControl/components/pulledFileComponent.svelte
+++ b/src/ui/sourceControl/components/pulledFileComponent.svelte
@@ -1,4 +1,3 @@
-<!-- @ts-ignore -->
 <script lang="ts">
     import { TFile } from "obsidian";
     import { hoverPreview } from "obsidian-community-lib";

--- a/src/ui/sourceControl/sourceControl.ts
+++ b/src/ui/sourceControl/sourceControl.ts
@@ -1,9 +1,6 @@
 import { HoverParent, HoverPopover, ItemView, WorkspaceLeaf } from "obsidian";
 import { SOURCE_CONTROL_VIEW_CONFIG } from "src/constants";
 import ObsidianGit from "src/main";
-// @tsconfig/svelte is required to resolve this error.
-// Ignore temporarily.
-// @ts-ignore
 import SourceControlViewComponent from "./sourceControl.svelte";
 
 export default class GitView extends ItemView implements HoverParent {


### PR DESCRIPTION
Remove some `@ts-ignore` comments that are not suppressing any type errors currently.