### PR TITLE
replace git-pull-request icon with lucide icon

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,7 +60,7 @@ export const DEFAULT_SETTINGS: Omit<ObsidianGitSettings, "autoCommitMessage"> =
 export const SOURCE_CONTROL_VIEW_CONFIG = {
     type: "git-view",
     name: "Source Control",
-    icon: "git-pull-request",
+    icon: "lucide-git-pull-request-arrow",
 };
 
 export const HISTORY_VIEW_CONFIG = {
@@ -72,5 +72,5 @@ export const HISTORY_VIEW_CONFIG = {
 export const DIFF_VIEW_CONFIG = {
     type: "diff-view",
     name: "Diff View",
-    icon: "git-pull-request",
+    icon: "lucide-git-pull-request-arrow",
 };


### PR DESCRIPTION
The current icons for the diff and source control view don't have the proper `stroke` and `fill` config, so they end up always being black. This replaces them with the built-in lucide icon for git pull requests.

Before:
![image](https://github.com/denolehov/obsidian-git/assets/4851889/1d446224-e1c7-424c-b858-74a74a1107ae)

After:
![image](https://github.com/denolehov/obsidian-git/assets/4851889/0529c928-9aed-4d62-a216-5c3cced36d32)
